### PR TITLE
Feature/stab fixes sessions flows

### DIFF
--- a/src/agent/src/compiler/compiler.lua
+++ b/src/agent/src/compiler/compiler.lua
@@ -295,7 +295,7 @@ local function process_tools(raw_spec, additional_tools, trait_contexts, trait_t
         if tool_info.inline_schema then
             tool_entry.description = tool_info.description or ("Inline tool: " .. canonical_name)
             tool_entry.schema = tool_info.inline_schema
-            tool_entry.registry_id = nil
+            tool_entry.registry_id = tool_info.id  -- FIX: Preserve registry_id even with inline schema
             tool_entry.meta = {}
         else
             if trait_tool_schemas[canonical_name] then

--- a/src/docs/docs/process.spec.md
+++ b/src/docs/docs/process.spec.md
@@ -123,6 +123,7 @@ local message = inbox:receive()
 -- Access message properties
 print("Topic:", message:topic())
 local payload = message:payload()
+local from_pid = message:from()
 
 -- Convert payload to Lua data
 local data = payload:data()

--- a/src/llm/src/claude/mapper.lua
+++ b/src/llm/src/claude/mapper.lua
@@ -251,6 +251,15 @@ local function consolidate_messages(messages)
     return result
 end
 
+local function ensure_content_exists(messages)
+    for i = 1, #messages - 1 do
+        if not messages[i].content or #messages[i].content == 0 then
+            messages[i].content = {{ type = "text", text = "intercepted" }}
+        end
+    end
+    return messages
+end
+
 function mapper.map_messages(contract_messages)
     if not contract_messages or #contract_messages == 0 then
         return {
@@ -446,6 +455,7 @@ function mapper.map_messages(contract_messages)
     end
 
     claude_messages = consolidate_messages(claude_messages)
+    claude_messages = ensure_content_exists(claude_messages)
 
     return {
         messages = claude_messages,

--- a/src/llm/src/openai/client.lua
+++ b/src/llm/src/openai/client.lua
@@ -80,7 +80,11 @@ local function parse_error_response(http_response)
     local error_info = {
         status_code = http_response and http_response.status_code or 0,
         message = "OpenAI API error: " .. (http_response and http_response.status_code or "connection failed")
+
     }
+
+    -- open router and other providers sometimes store error in various places
+    print("error detected", http_response.body)
 
     -- Add request ID if available
     if http_response and http_response.headers and http_response.headers["x-request-id"] then
@@ -203,6 +207,8 @@ function openai_client.request(endpoint_path, payload, options)
             payload.stream_options = {
                 include_usage = true
             }
+        else
+            payload.usage = { include = true }
         end
 
         http_options.body = json.encode(payload)


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the Claude and OpenAI mappers, as well as updates to the Stream module documentation. The most significant changes include stricter tool ID sanitization and handling for Claude integration, improved merging logic for developer messages, a more robust approach to empty function call arguments in the OpenAI mapper, and a comprehensive rewrite of the Stream module's documentation to clarify its API and behavior.

**Claude Mapper Improvements:**

- Added a `sanitize_tool_id` function to enforce Claude's tool ID format and applied it wherever tool IDs are set or read, preventing invalid tool IDs from causing errors. [[1]](diffhunk://#diff-6595aa6f693bd530b39d30778201f136afd16643b9d8a7dee27fa2fdb84c0ba3R47-R69) [[2]](diffhunk://#diff-6595aa6f693bd530b39d30778201f136afd16643b9d8a7dee27fa2fdb84c0ba3L293-R341) [[3]](diffhunk://#diff-6595aa6f693bd530b39d30778201f136afd16643b9d8a7dee27fa2fdb84c0ba3L311-R359) [[4]](diffhunk://#diff-6595aa6f693bd530b39d30778201f136afd16643b9d8a7dee27fa2fdb84c0ba3L343-R391) [[5]](diffhunk://#diff-6595aa6f693bd530b39d30778201f136afd16643b9d8a7dee27fa2fdb84c0ba3L524-R572)
- Improved merging logic for developer messages: now, if the previous message is a tool result or if there are no previous messages, a new user message is created instead of merging, ensuring correct message sequencing.

**OpenAI Mapper Fixes:**

- Fixed an issue where empty function call arguments would serialize as `{}` by replacing them with `{ invoke = true }`, ensuring downstream compatibility.
- Adjusted prompt token calculation to subtract cached tokens, providing more accurate token usage reporting.

**Documentation Updates:**

- Completely rewrote the `Stream` module documentation to clarify its API, including chunk-based and token-based reading, scanner lifecycle, async behavior, error handling, and best practices. This makes the module's usage and expected behaviors much clearer for developers. [[1]](diffhunk://#diff-38faad9c9135efccf9127b93ea58ec4565aa6aeffb6244bbeaab27d1454c102eL5-R5) [[2]](diffhunk://#diff-38faad9c9135efccf9127b93ea58ec4565aa6aeffb6244bbeaab27d1454c102eL16-R145)

**Minor/Other:**

- Added retrieval of the `from` PID in the message processing spec for completeness.
- Removed extraneous newlines and minor formatting tweaks in the OpenAI mapper for code cleanliness. [[1]](diffhunk://#diff-73923e93711bce133ea45c2014fc3b121c3974280098f0df97ad6e680050e620L156) [[2]](diffhunk://#diff-73923e93711bce133ea45c2014fc3b121c3974280098f0df97ad6e680050e620L165) [[3]](diffhunk://#diff-73923e93711bce133ea45c2014fc3b121c3974280098f0df97ad6e680050e620L206) [[4]](diffhunk://#diff-73923e93711bce133ea45c2014fc3b121c3974280098f0df97ad6e680050e620L241) [[5]](diffhunk://#diff-73923e93711bce133ea45c2014fc3b121c3974280098f0df97ad6e680050e620L260-L264)