### PR TITLE
- fixes invalid openrouter mapping for openai sync requests

### DIFF
--- a/src/llm/src/openai/client.lua
+++ b/src/llm/src/openai/client.lua
@@ -208,7 +208,9 @@ function openai_client.request(endpoint_path, payload, options)
                 include_usage = true
             }
         else
-            payload.usage = { include = true }
+            if config.base_url:match("openrouter") then
+                payload.usage = { include = true }
+            end
         end
 
         http_options.body = json.encode(payload)

--- a/src/relay/src/central.lua
+++ b/src/relay/src/central.lua
@@ -7,7 +7,6 @@ local plugin_discovery = require("plugin_discovery")
 local logger = require("logger"):named("relay")
 
 local function run()
-    -- Load configuration
     local config = consts.get_config()
 
     logger:info("relay central hub starting", {
@@ -15,7 +14,6 @@ local function run()
         inactivity_timeout = config.user_hub_inactivity_timeout
     })
 
-    -- Validate required configuration
     if not config.user_security_scope or config.user_security_scope == "" then
         error("RELAY_USER_SECURITY_SCOPE environment variable is required")
     end
@@ -24,7 +22,6 @@ local function run()
         error("RELAY_HOST environment variable is required")
     end
 
-    -- Discover plugins once at startup
     local plugins, plugin_err = plugin_discovery.get_plugins()
     if plugin_err then
         error("Failed to discover plugins: " .. plugin_err)
@@ -32,28 +29,20 @@ local function run()
 
     logger:info("plugin discovery complete", { plugin_count = table_length(plugins) })
 
-    -- Initialize state
     local state = {
         config = config,
         plugins = plugins,
-        user_hubs = {}, -- user_id -> { hub_pid, last_activity, client_count }
+        user_hubs = {},
         total_hubs = 0
     }
 
-    -- Register this process
     process.registry.register(consts.CENTRAL_HUB_REGISTRY_NAME)
-
-    -- Set trap_links to handle user hub failures gracefully
     process.set_options({ trap_links = true })
 
-    -- Set up GC ticker
     local gc_ticker = time.ticker(config.gc_check_interval)
-
-    -- Set up channels
     local inbox = process.inbox()
     local events = process.events()
 
-    -- Main loop
     while true do
         local result = channel.select({
             inbox:case_receive(),
@@ -73,14 +62,12 @@ local function run()
             if topic == consts.WS_TOPICS.JOIN then
                 handle_client_connection(state, payload.client_pid, payload.metadata)
             elseif topic == consts.WS_TOPICS.LEAVE then
-                -- Log user leave in central for tracking
                 if payload.metadata and payload.metadata.user_id then
                     logger:info("user leaving central hub", { user_id = payload.metadata.user_id })
                 end
             elseif topic == consts.HUB_TOPICS.ACTIVITY_UPDATE then
                 handle_activity_update(state, payload)
             else
-                -- Broadcast unknown messages to all user hubs
                 for user_id, hub_info in pairs(state.user_hubs) do
                     if hub_info.hub_pid then
                         process.send(hub_info.hub_pid, topic, payload)
@@ -90,6 +77,10 @@ local function run()
 
         elseif result.channel == events then
             local event = result.value
+            if event.kind == process.event.CANCEL then
+                logger:info("received cancel signal")
+                break
+            end
             handle_process_event(state, event)
 
         elseif result.channel == gc_ticker:channel() then
@@ -97,12 +88,10 @@ local function run()
         end
     end
 
-    -- Cleanup on exit
     gc_ticker:stop()
 
     logger:info("shutting down relay central hub", { active_hubs = state.total_hubs })
 
-    -- Cancel all user hubs
     for user_id, hub_info in pairs(state.user_hubs) do
         if hub_info.hub_pid then
             process.cancel(hub_info.hub_pid, consts.CANCEL_TIMEOUT)
@@ -118,7 +107,6 @@ function table_length(t)
     return count
 end
 
--- Handle client connection request
 function handle_client_connection(state, client_pid, metadata)
     local user_id = metadata and metadata.user_id
     if not user_id then
@@ -129,7 +117,6 @@ function handle_client_connection(state, client_pid, metadata)
         return
     end
 
-    -- Check connection limit
     if state.user_hubs[user_id] and
        state.user_hubs[user_id].client_count >= state.config.max_connections_per_user then
         logger:warn("connection limit exceeded", { user_id = user_id, limit = state.config.max_connections_per_user })
@@ -141,7 +128,6 @@ function handle_client_connection(state, client_pid, metadata)
         return
     end
 
-    -- Get or create user hub
     local user_hub_pid = get_or_create_user_hub(state, user_id, metadata)
     if not user_hub_pid then
         logger:error("user hub creation failed", { user_id = user_id })
@@ -152,37 +138,30 @@ function handle_client_connection(state, client_pid, metadata)
         return
     end
 
-    -- Send control message to redirect client
     process.send(client_pid, consts.WS_TOPICS.CONTROL, {
         target_pid = user_hub_pid,
         metadata = metadata,
         plugins = state.plugins
     })
 
-    -- Update activity
     if state.user_hubs[user_id] then
         state.user_hubs[user_id].last_activity = time.now()
     end
 end
 
--- Get or create user hub for user
 function get_or_create_user_hub(state, user_id, metadata)
-    -- Check if hub already exists
     if state.user_hubs[user_id] and state.user_hubs[user_id].hub_pid then
         return state.user_hubs[user_id].hub_pid
     end
 
-    -- Create user actor
     local user_metadata = metadata.user_metadata or {}
     local user_actor = security.new_actor(user_id, user_metadata)
 
-    -- Get user scope
     local user_scope, scope_err = security.named_scope(state.config.user_security_scope)
     if scope_err then
         error("Failed to get user security scope: " .. scope_err)
     end
 
-    -- Spawn user hub process with linking and monitoring
     local hub_pid, err = process.with_context({})
         :with_scope(user_scope)
         :with_actor(user_actor)
@@ -203,7 +182,6 @@ function get_or_create_user_hub(state, user_id, metadata)
         return nil
     end
 
-    -- Store hub info
     state.user_hubs[user_id] = {
         hub_pid = hub_pid,
         created_at = time.now(),
@@ -218,7 +196,6 @@ function get_or_create_user_hub(state, user_id, metadata)
     return hub_pid
 end
 
--- Handle activity updates from user hubs
 function handle_activity_update(state, payload)
     local user_id = payload.user_id
     if user_id and state.user_hubs[user_id] then
@@ -232,7 +209,6 @@ function handle_activity_update(state, payload)
     end
 end
 
--- Handle process events
 function handle_process_event(state, event)
     if event.kind ~= process.event.EXIT and event.kind ~= process.event.LINK_DOWN then
         return
@@ -240,7 +216,6 @@ function handle_process_event(state, event)
 
     local from_pid = event.from
 
-    -- Find and remove terminated hub
     for user_id, hub_info in pairs(state.user_hubs) do
         if hub_info.hub_pid == from_pid then
             state.user_hubs[user_id] = nil
@@ -256,18 +231,15 @@ function handle_process_event(state, event)
     end
 end
 
--- Check for inactive user hubs
 function check_inactive_hubs(state)
     local now = time.now()
     local inactivity_duration, _ = time.parse_duration(state.config.user_hub_inactivity_timeout)
 
     for user_id, hub_info in pairs(state.user_hubs) do
-        -- Skip if hub has clients or is being terminated
         if hub_info.client_count > 0 or hub_info.terminating then
             goto continue
         end
 
-        -- Check inactivity
         local last_activity = hub_info.last_activity or hub_info.created_at
         local time_since_activity = now:sub(last_activity)
 


### PR DESCRIPTION
This pull request primarily refactors the `src/relay/src/central.lua` file to improve code readability and maintainability by removing redundant comments and streamlining logic. It also introduces a minor logic update in the OpenAI client to support usage reporting for OpenRouter endpoints. The main functional flow remains unchanged, but the code is now cleaner and easier to follow.

### Codebase cleanup and readability improvements

* Removed redundant comments throughout `central.lua`, making the code more concise and focused on logic rather than commentary. [[1]](diffhunk://#diff-692807e055cd0b33b3f34b21be03495cf4426e4413f093383884ea97ef42a1a9L10-L18) [[2]](diffhunk://#diff-692807e055cd0b33b3f34b21be03495cf4426e4413f093383884ea97ef42a1a9L27-L56) [[3]](diffhunk://#diff-692807e055cd0b33b3f34b21be03495cf4426e4413f093383884ea97ef42a1a9L76-L83) [[4]](diffhunk://#diff-692807e055cd0b33b3f34b21be03495cf4426e4413f093383884ea97ef42a1a9R80-L105) [[5]](diffhunk://#diff-692807e055cd0b33b3f34b21be03495cf4426e4413f093383884ea97ef42a1a9L121) [[6]](diffhunk://#diff-692807e055cd0b33b3f34b21be03495cf4426e4413f093383884ea97ef42a1a9L132) [[7]](diffhunk://#diff-692807e055cd0b33b3f34b21be03495cf4426e4413f093383884ea97ef42a1a9L144) [[8]](diffhunk://#diff-692807e055cd0b33b3f34b21be03495cf4426e4413f093383884ea97ef42a1a9L155-L185) [[9]](diffhunk://#diff-692807e055cd0b33b3f34b21be03495cf4426e4413f093383884ea97ef42a1a9L206) [[10]](diffhunk://#diff-692807e055cd0b33b3f34b21be03495cf4426e4413f093383884ea97ef42a1a9L221) [[11]](diffhunk://#diff-692807e055cd0b33b3f34b21be03495cf4426e4413f093383884ea97ef42a1a9L235-L243) [[12]](diffhunk://#diff-692807e055cd0b33b3f34b21be03495cf4426e4413f093383884ea97ef42a1a9L259-L270)

### Minor logic improvements

* Added handling for process cancel events in the central hub loop, allowing for graceful shutdown when a cancel signal is received.

### OpenAI client update

* Updated the OpenAI client logic to include usage reporting for OpenRouter endpoints by setting `payload.usage = { include = true }` when the base URL matches "openrouter".