### PR TITLE
Fix the error-to-string conversion

### DIFF
--- a/src/bootloader/src/bootloader.lua
+++ b/src/bootloader/src/bootloader.lua
@@ -174,7 +174,7 @@ local function execute_bootloader(entry, options, completed_bootloaders)
 
         return {
             status = "error",
-            message = "Dependencies not met: " .. tostring(err)or_message,
+            message = "Dependencies not met: " .. tostring(error_message),
             duration = 0
         }
     end


### PR DESCRIPTION
## What was changed

Here: https://github.com/wippyai/framework/pull/33/files#diff-172c27be214dfd8a18ac72ae07dd6b9d725eaa35af8661f8d1209c10c3a36175R177 a typo was made.
