### PR TITLE
Bump facade CDN to 1.0.25

### DIFF
--- a/src/facade/Makefile
+++ b/src/facade/Makefile
@@ -6,7 +6,7 @@
 # Run `make sync` after every Wippy Web Host version bump to pull fresh copies.
 
 # Web Host CDN base — update version when Wippy Web Host releases
-WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.23
+WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.25
 
 # Files to sync from CDN into public/@wippy-fe/
 CDN_FILES = loading.js

--- a/src/facade/README.md
+++ b/src/facade/README.md
@@ -47,7 +47,7 @@ These fields are NOT configurable via requirements — they are computed at runt
 
 | Requirement | Default | Description |
 |---|---|---|
-| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.23` | CDN base URL for the Web Host frontend bundle |
+| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.25` | CDN base URL for the Web Host frontend bundle |
 | `fe_entry_path` | `/iframe.html` | Iframe HTML entry point path (appended to `fe_facade_url`) |
 
 ### App Identity
@@ -189,9 +189,9 @@ Only override what differs from defaults.
 
 ```json
 {
-  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.23",
+  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.25",
   "iframe_origin": "https://web-host.wippy.ai",
-  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.23/iframe.html?waitForCustomConfig",
+  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.25/iframe.html?waitForCustomConfig",
   "login_path": "/login.html",
   "env": {
     "APP_API_URL": "http://localhost:8085",

--- a/src/facade/_index.yaml
+++ b/src/facade/_index.yaml
@@ -33,7 +33,7 @@ entries:
     targets:
       - entry: wippy.facade:fe_facade_url
         path: .default
-    default: https://web-host.wippy.ai/webcomponents-1.0.23
+    default: https://web-host.wippy.ai/webcomponents-1.0.25
 
   - name: fe_entry_path
     kind: ns.requirement

--- a/src/facade/config_handler_test.lua
+++ b/src/facade/config_handler_test.lua
@@ -112,7 +112,7 @@ local function define_tests()
             end)
 
             test.it("extracts iframe origin from facade URL", function()
-                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.23"
+                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.25"
                 local origin = facade_url:match("^(https?://[^/]+)")
 
                 test.eq(origin, "https://web-host.wippy.ai")


### PR DESCRIPTION

## Summary

- Bumps `wippy.facade:fe_facade_url` default from `webcomponents-1.0.23` to `webcomponents-1.0.25`.
- Skipped 1.0.24 — last reference here was 1.0.23.
- Touches `src/facade/Makefile` (WEB_HOST_CDN), `src/facade/README.md` (defaults table), `src/facade/_index.yaml` (`fe_facade_url` default), and `src/facade/config_handler_test.lua` (test fixture).

## Verification

- `wippy lint` clean for both `src/facade` (2 entries) and `src/facade/test` (8 entries).
- `wippy run test` blocked by a pre-existing Windows symlink artifact (`src/facade/test/public` stored as text ../public because Git on Windows uses `core.symlinks=false`). Unrelated to this bump — runs fine on Unix CI.
- Re-ran \`make sync\` against the new URL — vendored `loading.js` content is byte-identical between 1.0.23 → 1.0.25 (the loading component didn't move this window), so no vendored-file delta is included.

## Test plan

- [ ] CI lints green on Linux runner
- [ ] CI tests green on Linux runner (test/public symlink works there)
- [ ] Manually: facade serves the new CDN URL via \`wippy.exe run -c\` against any consumer
