### PR TITLE
Bump facade CDN default to 1.0.26

### DIFF
--- a/src/facade/Makefile
+++ b/src/facade/Makefile
@@ -6,7 +6,7 @@
 # Run `make sync` after every Wippy Web Host version bump to pull fresh copies.
 
 # Web Host CDN base — update version when Wippy Web Host releases
-WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.25
+WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.26
 
 # Files to sync from CDN into public/@wippy-fe/
 CDN_FILES = loading.js

--- a/src/facade/README.md
+++ b/src/facade/README.md
@@ -66,7 +66,7 @@ These fields are NOT configurable via requirements — they are computed at runt
 
 | Requirement | Default | Description |
 |---|---|---|
-| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.25` | CDN base URL for the Web Host frontend bundle |
+| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.26` | CDN base URL for the Web Host frontend bundle |
 | `fe_entry_path` | `/iframe.html` | Iframe HTML entry point path (appended to `fe_facade_url`) |
 | `fe_mode` | `compat` | `compat` (default — loads `module.js`) or `managed` (loads `managed-layout.js` for declarative multi-panel apps). See [Modes](#modes) above |
 
@@ -209,9 +209,9 @@ Only override what differs from defaults.
 
 ```json
 {
-  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.25",
+  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.26",
   "iframe_origin": "https://web-host.wippy.ai",
-  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.25/iframe.html?waitForCustomConfig",
+  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.26/iframe.html?waitForCustomConfig",
   "login_path": "/login.html",
   "env": {
     "APP_API_URL": "http://localhost:8085",

--- a/src/facade/_index.yaml
+++ b/src/facade/_index.yaml
@@ -33,7 +33,7 @@ entries:
     targets:
       - entry: wippy.facade:fe_facade_url
         path: .default
-    default: https://web-host.wippy.ai/webcomponents-1.0.25
+    default: https://web-host.wippy.ai/webcomponents-1.0.26
 
   - name: fe_entry_path
     kind: ns.requirement

--- a/src/facade/config_handler_test.lua
+++ b/src/facade/config_handler_test.lua
@@ -112,7 +112,7 @@ local function define_tests()
             end)
 
             test.it("extracts iframe origin from facade URL", function()
-                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.25"
+                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.26"
                 local origin = facade_url:match("^(https?://[^/]+)")
 
                 test.eq(origin, "https://web-host.wippy.ai")


### PR DESCRIPTION
## Summary
- Bumps the four facade references that pin the Wippy Web Host CDN version to **1.0.26**:
  - \`src/facade/_index.yaml\` — \`fe_facade_url\` default
  - \`src/facade/Makefile\` — \`WEB_HOST_CDN\` constant
  - \`src/facade/README.md\` — sample config + integration example
  - \`src/facade/config_handler_test.lua\` — test fixture facade URL

Wippy Web Host \`1.0.26\` is already deployed at \`web-host.wippy.ai/webcomponents-1.0.26/\` and the supporting npm packages (\`@wippy-fe/*@0.0.26\`) are published. Verified end-to-end with app-template clean rebuild + smoke (login page renders, all four CSS assets fetched HTTP 200).
