### PR TITLE
Fix deterministic migration ordering

### DIFF
--- a/src/migration/registry.lua
+++ b/src/migration/registry.lua
@@ -21,6 +21,25 @@ local migrations = {}
 
 migrations._registry = registry
 
+local function migration_timestamp(entry: any): string
+    local meta = entry and entry.meta
+    if type(meta) ~= "table" or meta.timestamp == nil then
+        return ""
+    end
+    return tostring(meta.timestamp)
+end
+
+-- Timestamp is optional. Full id is the deterministic tie-breaker so legacy
+-- migrations without timestamps still run in a stable, inspectable order.
+function migrations.compare(a: any, b: any): boolean
+    local a_time = migration_timestamp(a)
+    local b_time = migration_timestamp(b)
+    if a_time ~= b_time then
+        return a_time < b_time
+    end
+    return tostring(a and a.id or "") < tostring(b and b.id or "")
+end
+
 -- Find migrations in registry based on provided options
 function migrations.find(options: any?): ({MigrationEntry}?, string?)
     local opts = options or {}
@@ -50,12 +69,7 @@ function migrations.find(options: any?): ({MigrationEntry}?, string?)
         return {}
     end
 
-    -- Sort entries by timestamp (ascending)
-    table.sort(entries, function(a: MigrationEntry, b: MigrationEntry): boolean
-        local a_time = a.meta and a.meta.timestamp or ""
-        local b_time = b.meta and b.meta.timestamp or ""
-        return a_time < b_time
-    end)
+    table.sort(entries, migrations.compare)
 
     return entries
 end

--- a/src/migration/registry_test.lua
+++ b/src/migration/registry_test.lua
@@ -65,6 +65,36 @@ local function define_tests()
             test.eq(results[3].id, "m:third")
         end)
 
+        test.it("sorts untimestamped migrations by id", function()
+            migration_registry._registry = mock_registry({
+                { id = "keeper.mcp.migrations:migration_06", kind = "function.lua", meta = { type = "migration" } },
+                { id = "keeper.mcp.migrations:migration_01", kind = "function.lua", meta = { type = "migration" } },
+                { id = "keeper.mcp.migrations:migration_02", kind = "function.lua", meta = { type = "migration" } },
+            })
+
+            local results, err = migration_registry.find()
+            test.is_nil(err)
+            test.eq(#results, 3)
+            test.eq(results[1].id, "keeper.mcp.migrations:migration_01")
+            test.eq(results[2].id, "keeper.mcp.migrations:migration_02")
+            test.eq(results[3].id, "keeper.mcp.migrations:migration_06")
+        end)
+
+        test.it("uses id as a timestamp tie-breaker", function()
+            migration_registry._registry = mock_registry({
+                { id = "m:beta", kind = "function.lua", meta = { type = "migration", timestamp = "2024-01-01" } },
+                { id = "m:alpha", kind = "function.lua", meta = { type = "migration", timestamp = "2024-01-01" } },
+                { id = "m:later", kind = "function.lua", meta = { type = "migration", timestamp = "2024-02-01" } },
+            })
+
+            local results, err = migration_registry.find()
+            test.is_nil(err)
+            test.eq(#results, 3)
+            test.eq(results[1].id, "m:alpha")
+            test.eq(results[2].id, "m:beta")
+            test.eq(results[3].id, "m:later")
+        end)
+
         test.it("filters by target_db", function()
             migration_registry._registry = mock_registry({
                 { id = "m:pg", kind = "function.lua", meta = { type = "migration", target_db = "app:db", timestamp = "2024-01-01" } },

--- a/src/migration/runner.lua
+++ b/src/migration/runner.lua
@@ -39,6 +39,24 @@ local function get_description(migration: any): any
     return ""
 end
 
+local function compare_applied(a: any, b: any): boolean
+    local a_applied_at = tostring(a.applied_at or "")
+    local b_applied_at = tostring(b.applied_at or "")
+    if a_applied_at ~= b_applied_at then
+        return a_applied_at < b_applied_at
+    end
+    return registry_finder.compare(a, b)
+end
+
+local function compare_rollback(a: any, b: any): boolean
+    local a_applied_at = tostring(a.applied_at or "")
+    local b_applied_at = tostring(b.applied_at or "")
+    if a_applied_at ~= b_applied_at then
+        return a_applied_at > b_applied_at
+    end
+    return registry_finder.compare(b.registry_entry or b, a.registry_entry or a)
+end
+
 local Runner = {}
 Runner.__index = Runner
 
@@ -113,15 +131,8 @@ function Runner:find_migrations(options: RunnerOptions?): ({any}?, string?)
         end
     end
 
-    table.sort(applied, function(a, b)
-        return (a.applied_at or "") < (b.applied_at or "")
-    end)
-
-    table.sort(pending, function(a, b)
-        local a_time = a.meta and a.meta.timestamp or ""
-        local b_time = b.meta and b.meta.timestamp or ""
-        return a_time < b_time
-    end)
+    table.sort(applied, compare_applied)
+    table.sort(pending, registry_finder.compare)
 
     local sorted = {}
     for _, m in ipairs(applied) do
@@ -477,9 +488,7 @@ function Runner:rollback(options: RunnerOptions?): any
         end
     end
 
-    table.sort(applied_migrations, function(a, b)
-        return (a.applied_at or "") > (b.applied_at or "")
-    end)
+    table.sort(applied_migrations, compare_rollback)
 
     local allowed_ids = options.allowed_ids or {}
 


### PR DESCRIPTION
## Summary
- sort migrations by timestamp with full id as deterministic fallback
- reuse the same comparator for pending/applied/rollback ordering
- add regressions for untimestamped migrations and equal timestamp tie-breaks

## Tests
- wippy lint (src/migration/test)
- wippy run test (src/migration/test)

Published: wippy/migration@0.3.16