### PR TITLE
Bump facade CDN to 1.0.29

### DIFF
--- a/src/facade/Makefile
+++ b/src/facade/Makefile
@@ -6,7 +6,7 @@
 # Run `make sync` after every Wippy Web Host version bump to pull fresh copies.
 
 # Web Host CDN base — update version when Wippy Web Host releases
-WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.28
+WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.29
 
 # Files to sync from CDN into public/@wippy-fe/
 CDN_FILES = loading.js

--- a/src/facade/Makefile
+++ b/src/facade/Makefile
@@ -6,7 +6,7 @@
 # Run `make sync` after every Wippy Web Host version bump to pull fresh copies.
 
 # Web Host CDN base — update version when Wippy Web Host releases
-WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.26
+WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.28
 
 # Files to sync from CDN into public/@wippy-fe/
 CDN_FILES = loading.js

--- a/src/facade/README.md
+++ b/src/facade/README.md
@@ -66,7 +66,7 @@ These fields are NOT configurable via requirements — they are computed at runt
 
 | Requirement | Default | Description |
 |---|---|---|
-| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.26` | CDN base URL for the Web Host frontend bundle |
+| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.28` | CDN base URL for the Web Host frontend bundle |
 | `fe_entry_path` | `/iframe.html` | Iframe HTML entry point path (appended to `fe_facade_url`) |
 | `fe_mode` | `compat` | `compat` (default — loads `module.js`) or `managed` (loads `managed-layout.js` for declarative multi-panel apps). See [Modes](#modes) above |
 
@@ -232,9 +232,9 @@ Scripts are fetched in parallel and awaited before the Web Host bundle is import
 
 ```json
 {
-  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.26",
+  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.28",
   "iframe_origin": "https://web-host.wippy.ai",
-  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.26/iframe.html?waitForCustomConfig",
+  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.28/iframe.html?waitForCustomConfig",
   "login_path": "/login.html",
   "env": {
     "APP_API_URL": "http://localhost:8085",

--- a/src/facade/README.md
+++ b/src/facade/README.md
@@ -66,7 +66,7 @@ These fields are NOT configurable via requirements — they are computed at runt
 
 | Requirement | Default | Description |
 |---|---|---|
-| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.28` | CDN base URL for the Web Host frontend bundle |
+| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.29` | CDN base URL for the Web Host frontend bundle |
 | `fe_entry_path` | `/iframe.html` | Iframe HTML entry point path (appended to `fe_facade_url`) |
 | `fe_mode` | `compat` | `compat` (default — loads `module.js`) or `managed` (loads `managed-layout.js` for declarative multi-panel apps). See [Modes](#modes) above |
 
@@ -232,9 +232,9 @@ Scripts are fetched in parallel and awaited before the Web Host bundle is import
 
 ```json
 {
-  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.28",
+  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.29",
   "iframe_origin": "https://web-host.wippy.ai",
-  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.28/iframe.html?waitForCustomConfig",
+  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.29/iframe.html?waitForCustomConfig",
   "login_path": "/login.html",
   "env": {
     "APP_API_URL": "http://localhost:8085",

--- a/src/facade/_index.yaml
+++ b/src/facade/_index.yaml
@@ -33,7 +33,7 @@ entries:
     targets:
       - entry: wippy.facade:fe_facade_url
         path: .default
-    default: https://web-host.wippy.ai/webcomponents-1.0.28
+    default: https://web-host.wippy.ai/webcomponents-1.0.29
 
   - name: fe_entry_path
     kind: ns.requirement
@@ -42,7 +42,7 @@ entries:
     targets:
       - entry: wippy.facade:fe_entry_path
         path: .default
-    default: /iframe.html
+    default: /iframe.html?live-yaml-test=1
 
   - name: fe_mode
     kind: ns.requirement

--- a/src/facade/_index.yaml
+++ b/src/facade/_index.yaml
@@ -42,7 +42,7 @@ entries:
     targets:
       - entry: wippy.facade:fe_entry_path
         path: .default
-    default: /iframe.html?live-yaml-test=1
+    default: /iframe.html
 
   - name: fe_mode
     kind: ns.requirement

--- a/src/facade/_index.yaml
+++ b/src/facade/_index.yaml
@@ -33,7 +33,7 @@ entries:
     targets:
       - entry: wippy.facade:fe_facade_url
         path: .default
-    default: https://web-host.wippy.ai/webcomponents-1.0.26
+    default: https://web-host.wippy.ai/webcomponents-1.0.28
 
   - name: fe_entry_path
     kind: ns.requirement

--- a/src/facade/config_handler_test.lua
+++ b/src/facade/config_handler_test.lua
@@ -114,7 +114,7 @@ local function define_tests()
             end)
 
             test.it("extracts iframe origin from facade URL", function()
-                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.26"
+                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.28"
                 local origin = facade_url:match("^(https?://[^/]+)")
 
                 test.eq(origin, "https://web-host.wippy.ai")

--- a/src/facade/config_handler_test.lua
+++ b/src/facade/config_handler_test.lua
@@ -114,7 +114,7 @@ local function define_tests()
             end)
 
             test.it("extracts iframe origin from facade URL", function()
-                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.28"
+                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.29"
                 local origin = facade_url:match("^(https?://[^/]+)")
 
                 test.eq(origin, "https://web-host.wippy.ai")


### PR DESCRIPTION
## Summary

- Bumps the facade's `fe_facade_url` default and the `Makefile` `WEB_HOST_CDN` from `webcomponents-1.0.26` to `webcomponents-1.0.29`
- Skips `1.0.27` (prepared on `feat/host-config-layout-requirement`, never merged) and `1.0.28` (superseded mid-PR by 1.0.29's hotfix)
- All 13 `@wippy-fe/*` workspace packages just published at `0.0.29` against the new host

## What's in 1.0.29 vs 1.0.26

- **Proxy api default 401 → `host.handleError('auth-expired')` response interceptor.** Single-flight per proxy-instance lifetime (a flood of in-flight requests after session expiry doesn't bounce 30 times). Per-request opt-out via `AxiosRequestConfig.skipDefaultAuth`. Cross-origin auto-skip — `api.get('https://api.openai.com/...')` never leaks the Wippy token and a 401 from a third party never triggers our auth-expired bounce. Previously each child app had to wire its own 401 → login interceptor; in practice many didn't (keeper-v5's three apps shipped without any 401 handling and showed stale UI on session expiry).
- **Cold-cache "Proxy globals not found" race fix in host shells.** Affected ~1/3 of cold-cache loads (iframe context unaffected). Both host shell roots are `defineAsyncComponent`'d, so `app.mount()` returned before `<VueAppGlobalConnector />` (the only writer of `window[GLOBAL_API_PROVIDER]`) mounted — the autoload-injected WC `<script>` tags fetched `@wippy-fe/proxy.js` and hit its eager-getter throw on undefined globals. Fix relocates `registerAutoloadComponents(...)` into the connector's `<script setup>` immediately after the globals write, so they run as one synchronous atomic block.
- Earlier 1.0.27/1.0.28 changes still land: `@wippy-fe/vite-plugin` package (consumer-side build helper), `@wippy-fe/shared` cross-boundary types, `<wippy-loading>`/`<wippy-error>` zero-dep components, deep-capture clipboard, modal-template registry + native `<dialog>` modal path, WS auth-failure → login redirect, lazy-WS lifecycle fixes.

## Files

- `src/facade/_index.yaml` — `fe_facade_url` default
- `src/facade/Makefile` — `WEB_HOST_CDN` constant used by `make sync` to pull `loading.js` etc.
- `src/facade/README.md` — three doc references
- `src/facade/config_handler_test.lua` — origin-extraction test fixture

## Commits

| Hash | Subject |
|------|---------|
| `1fa60c3` | Bump facade CDN to 1.0.28 (initial PR target — superseded) |
| `55e55b5` | Bump facade CDN to 1.0.29 |
| `310ea47` | facade: drop live-yaml-test marker from fe_entry_path default |

## Verification

The `live-yaml-test=1` query-string marker added to `fe_entry_path.default` (in `55e55b5`) was used to confirm that the consumer-side `wippy.lock` `replacements:` block correctly overrides the hub-fetched `.wippy/vendor/wippy/facade/_index.yaml` with this local checkout. The marker appeared at runtime when `wippy.exe run` booted in app-template — proving the replace wires correctly. Marker removed in `310ea47`. (Smoke test for the consumer-side `wippy.lock` workflow, not for the bump itself.)

## Note on branch name

Branch was originally named `chore/bump-facade-cdn-1.0.28` before the 1.0.29 hotfix landed in gen-2-chat. The PR target version is now 1.0.29; branch name kept as-is to preserve PR continuity (no force-rename of remote refs).

## Test plan

- [ ] CI on the `facade` package green (`config_handler_test.lua` updated alongside source)
- [ ] After merge: `make -C src/facade sync` pulls fresh `loading.js`, `@wippy-fe/proxy.js`, etc. from `webcomponents-1.0.29`
- [ ] A Wippy app using the facade bootstraps via `https://web-host.wippy.ai/webcomponents-1.0.29/iframe.html` once gen-2-chat host is deployed at that tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)