### PR TITLE
Bump facade CDN to 1.0.31

### DIFF
--- a/src/facade/Makefile
+++ b/src/facade/Makefile
@@ -6,7 +6,7 @@
 # Run `make sync` after every Wippy Web Host version bump to pull fresh copies.
 
 # Web Host CDN base — update version when Wippy Web Host releases
-WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.30
+WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.31
 
 # Files to sync from CDN into public/@wippy-fe/
 CDN_FILES = loading.js

--- a/src/facade/README.md
+++ b/src/facade/README.md
@@ -66,7 +66,7 @@ These fields are NOT configurable via requirements — they are computed at runt
 
 | Requirement | Default | Description |
 |---|---|---|
-| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.30` | CDN base URL for the Web Host frontend bundle |
+| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.31` | CDN base URL for the Web Host frontend bundle |
 | `fe_entry_path` | `/iframe.html` | Iframe HTML entry point path (appended to `fe_facade_url`) |
 | `fe_mode` | `compat` | `compat` (default — loads `module.js`) or `managed` (loads `managed-layout.js` for declarative multi-panel apps). See [Modes](#modes) above |
 
@@ -280,9 +280,9 @@ Scripts are fetched in parallel and awaited before the Web Host bundle is import
 
 ```json
 {
-  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.30",
+  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.31",
   "iframe_origin": "https://web-host.wippy.ai",
-  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.30/iframe.html?waitForCustomConfig",
+  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.31/iframe.html?waitForCustomConfig",
   "login_path": "/login.html",
   "login_redirect_param": null,
   "env": {

--- a/src/facade/_index.yaml
+++ b/src/facade/_index.yaml
@@ -33,7 +33,7 @@ entries:
     targets:
       - entry: wippy.facade:fe_facade_url
         path: .default
-    default: https://web-host.wippy.ai/webcomponents-1.0.30
+    default: https://web-host.wippy.ai/webcomponents-1.0.31
 
   - name: fe_entry_path
     kind: ns.requirement

--- a/src/facade/config_handler_test.lua
+++ b/src/facade/config_handler_test.lua
@@ -117,7 +117,7 @@ local function define_tests()
             end)
 
             test.it("extracts iframe origin from facade URL", function()
-                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.30"
+                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.31"
                 local origin = facade_url:match("^(https?://[^/]+)")
 
                 test.eq(origin, "https://web-host.wippy.ai")


### PR DESCRIPTION
Wippy Web Host 1.0.31 release brings:

- \`@wippy-fe/webcomponent-core\`: opt-in reactive primitive (\`this.reactive.props.subscribe\` / \`events.emit\`) — framework-agnostic reactive bindings on \`WippyElement\`, no Vue dependency for non-Vue consumers. Vue variant refactored to bridge the core adapter into Vue refs (composables unchanged).
- \`$W.sanitize(html, opts?)\` proxy API — default-allowlisted HTML sanitizer that auto-allows currently-registered WC tags (\`loadByTagName\` / \`loadWebComponent\` / autoload all push into a per-context tag-allowlist tracker; the tracker mirrors into \`hostConfig.allowAdditionalTags\` so the host's chat sanitizer picks up on-demand-loaded tags too).
- \`sanitize-html\` + \`markdown-it\` + \`markdown-it-async\` externalized via the import map — child apps \`import sanitizeHtml from 'sanitize-html'\` / \`import MarkdownIt from 'markdown-it'\` instead of bundling their own copies.
- Docs pass: README import-map table covers all 16 entries, \`iframe-proxy.md\` gains Web Component Loading + HTML Sanitization sections, \`web_components.spec.md\` gains a Reactive Bindings (opt-in) section, \`pinia-persist\` README expanded to a full API reference.

Web Host totals: 477 tests across 29 files (+51 from 1.0.30); pnpm build / lint clean; verified E2E in app-template-raw with dev FE mode against the local 1.0.31 build.

Refs updated in \`src/facade/{_index.yaml, README.md, Makefile, config_handler_test.lua}\`. Vendored \`public/@wippy-fe/loading.js\` is byte-identical to 1.0.30 (no change in the loading package source between releases), so no re-vendor needed this cycle.

\`wippy lint --level error\`: 8 entries, no issues.

## Test plan

- [ ] CI passes
- [ ] After merge, publish \`wippy/facade@0.6.5\` so app-template's vendor lock can pull the new version on \`wippy update\`