### PR TITLE
chore(facade): bump web-host CDN to 1.0.34

### DIFF
--- a/src/facade/Makefile
+++ b/src/facade/Makefile
@@ -6,7 +6,7 @@
 # Run `make sync` after every Wippy Web Host version bump to pull fresh copies.
 
 # Web Host CDN base — update version when Wippy Web Host releases
-WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.30
+WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.34
 
 # Files to sync from CDN into public/@wippy-fe/
 CDN_FILES = loading.js

--- a/src/facade/README.md
+++ b/src/facade/README.md
@@ -66,7 +66,7 @@ These fields are NOT configurable via requirements — they are computed at runt
 
 | Requirement | Default | Description |
 |---|---|---|
-| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.30` | CDN base URL for the Web Host frontend bundle |
+| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.34` | CDN base URL for the Web Host frontend bundle |
 | `fe_entry_path` | `/iframe.html` | Iframe HTML entry point path (appended to `fe_facade_url`) |
 | `fe_mode` | `compat` | `compat` (default — loads `module.js`) or `managed` (loads `managed-layout.js` for declarative multi-panel apps). See [Modes](#modes) above |
 
@@ -280,9 +280,9 @@ Scripts are fetched in parallel and awaited before the Web Host bundle is import
 
 ```json
 {
-  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.30",
+  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.34",
   "iframe_origin": "https://web-host.wippy.ai",
-  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.30/iframe.html?waitForCustomConfig",
+  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.34/iframe.html?waitForCustomConfig",
   "login_path": "/login.html",
   "login_redirect_param": null,
   "env": {

--- a/src/facade/_index.yaml
+++ b/src/facade/_index.yaml
@@ -33,7 +33,7 @@ entries:
     targets:
       - entry: wippy.facade:fe_facade_url
         path: .default
-    default: https://web-host.wippy.ai/webcomponents-1.0.30
+    default: https://web-host.wippy.ai/webcomponents-1.0.34
 
   - name: fe_entry_path
     kind: ns.requirement

--- a/src/facade/config_handler_test.lua
+++ b/src/facade/config_handler_test.lua
@@ -117,7 +117,7 @@ local function define_tests()
             end)
 
             test.it("extracts iframe origin from facade URL", function()
-                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.30"
+                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.34"
                 local origin = facade_url:match("^(https?://[^/]+)")
 
                 test.eq(origin, "https://web-host.wippy.ai")


### PR DESCRIPTION

## Summary

- Bumps `fe_facade_url` default + `Makefile` sync target + `README.md` doc fixtures + `config_handler_test.lua` from `webcomponents-1.0.30` to `webcomponents-1.0.34` (4 files in `src/facade/`).
- Tracks Wippy Web Host 1.0.34 release — installVueWarnSuppressor + bridge sync-throw fix + normalizeError hardening. See [gen-2-chat CHANGELOG 1.0.34](https://github.com/wippy-ai/gen-2-chat/blob/webcomponents/CHANGELOG.md).