### PR TITLE
feat(facade): tanstack passthrough + theme persistence; Web Host CDN 1.0.41 (EE2-2265, EE2-2274)

### DIFF
--- a/src/facade/Makefile
+++ b/src/facade/Makefile
@@ -6,7 +6,7 @@
 # Run `make sync` after every Wippy Web Host version bump to pull fresh copies.
 
 # Web Host CDN base — update version when Wippy Web Host releases
-WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.40
+WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.41
 
 # Files to sync from CDN into public/@wippy-fe/
 CDN_FILES = loading.js

--- a/src/facade/Makefile
+++ b/src/facade/Makefile
@@ -6,7 +6,7 @@
 # Run `make sync` after every Wippy Web Host version bump to pull fresh copies.
 
 # Web Host CDN base — update version when Wippy Web Host releases
-WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.39
+WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.40
 
 # Files to sync from CDN into public/@wippy-fe/
 CDN_FILES = loading.js

--- a/src/facade/README.md
+++ b/src/facade/README.md
@@ -66,7 +66,7 @@ These fields are NOT configurable via requirements — they are computed at runt
 
 | Requirement | Default | Description |
 |---|---|---|
-| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.39` | CDN base URL for the Web Host frontend bundle |
+| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.40` | CDN base URL for the Web Host frontend bundle |
 | `fe_entry_path` | `/iframe.html` | Iframe HTML entry point path (appended to `fe_facade_url`) |
 | `fe_mode` | `compat` | `compat` (default — loads `module.js`) or `managed` (loads `managed-layout.js` for declarative multi-panel apps). See [Modes](#modes) above |
 
@@ -372,9 +372,9 @@ Returns an empty body (200 OK) when no variables are configured. Response has `C
 
 ```json
 {
-  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.39",
+  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.40",
   "iframe_origin": "https://web-host.wippy.ai",
-  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.39/iframe.html?waitForCustomConfig",
+  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.40/iframe.html?waitForCustomConfig",
   "login_path": "/login.html",
   "login_redirect_param": null,
   "env": {

--- a/src/facade/README.md
+++ b/src/facade/README.md
@@ -109,6 +109,7 @@ These accept JSON strings for complex configuration:
 | `allow_additional_tags` | `{}` | `hostConfig.allowAdditionalTags` | HTML sanitizer tag whitelist (e.g. `{"w-chart":["data","type"]}`) |
 | `chat` | `{}` | `hostConfig.chat` | Chat config (e.g. `{"convertPasteToFile":{"enabled":true,"minFileSize":1024,"allowHtml":false}}`) |
 | `axios_defaults` | `{}` | `axiosDefaults` | HTTP client defaults (e.g. `{"timeout":30000}`) — top-level, not under hostConfig |
+| `tanstack` | `{}` | `tanstack` | TanStack Query defaults — top-level, not under hostConfig. `{ default?, content?, lists? }`: `default` applies to all queries, `content` to single-resource renders, `lists` to navigation/index queries. Host default is `refetchOnWindowFocus:false` (e.g. `{"lists":{"refetchOnWindowFocus":true}}`) |
 | `extra_scripts` | `[]` | `extraScripts` | External `<script>` tags injected into `index.html` before the Web Host bundle loads. See [Extra scripts](#extra-scripts). |
 
 ### Auth

--- a/src/facade/README.md
+++ b/src/facade/README.md
@@ -66,7 +66,7 @@ These fields are NOT configurable via requirements — they are computed at runt
 
 | Requirement | Default | Description |
 |---|---|---|
-| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.40` | CDN base URL for the Web Host frontend bundle |
+| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.41` | CDN base URL for the Web Host frontend bundle |
 | `fe_entry_path` | `/iframe.html` | Iframe HTML entry point path (appended to `fe_facade_url`) |
 | `fe_mode` | `compat` | `compat` (default — loads `module.js`) or `managed` (loads `managed-layout.js` for declarative multi-panel apps). See [Modes](#modes) above |
 
@@ -94,6 +94,11 @@ Host-only UI flags — NOT sent to child iframes.
 | `hide_session_selector` | `false` | bool (`== "true"`) | Hide the chat session selector dropdown |
 | `session_type` | `non-persistent` | string | Chat session persistence (`non-persistent` or `cookie`) |
 | `history_mode` | `hash` | string | Browser history mode (`hash` or `browser`) |
+| `theme_mode` | `auto` | string | Forced theme: `auto` (follow OS), `light`, or `dark` |
+| `theme_persist` | `none` | string | Persist the user's chosen theme across reloads: `none`, `cookie`, or `localStorage`. `cookie` is read server-side by the Jet shell so the first paint is already themed (no flash). |
+| `theme_storage_key` | `@wippy-theme-mode` | string | Cookie / localStorage key the theme is stored under. Returned in `/facade/config` as `themeStorageKey` and baked into `/api/public/facade/theme-persist.js`. |
+
+> **Theme persistence:** when `theme_persist` is `cookie` or `localStorage`, include the facade-generated script — `<script src="/api/public/facade/theme-persist.js"></script>` — in the `<head>` of any page that should share the theme (the host shell already does). It applies the stored theme before paint and exposes `window.wippyThemePersist` (`read`, `write`, `apply`). The Web Host emits a `themeChanged` event the shell uses to persist changes.
 
 > **Boolean parsing:** `show_admin` defaults to `true` (any value except `"false"` is truthy). All other boolean flags default to `false` (only `"true"` is truthy).
 
@@ -372,9 +377,9 @@ Returns an empty body (200 OK) when no variables are configured. Response has `C
 
 ```json
 {
-  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.40",
+  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.41",
   "iframe_origin": "https://web-host.wippy.ai",
-  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.40/iframe.html?waitForCustomConfig",
+  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.41/iframe.html?waitForCustomConfig",
   "login_path": "/login.html",
   "login_redirect_param": null,
   "env": {

--- a/src/facade/_index.yaml
+++ b/src/facade/_index.yaml
@@ -17,15 +17,19 @@ entries:
     targets:
       - entry: wippy.facade:static
         path: .meta.server
+      - entry: wippy.facade:web_router
+        path: .meta.server
 
   - name: router
     kind: ns.requirement
     meta:
-      description: Public API router for config and CSS variable endpoints
+      description: Public API router for config, CSS variable, and theme-persist endpoints
     targets:
       - entry: wippy.facade:config_endpoint
         path: .meta.router
       - entry: wippy.facade:css_vars_endpoint
+        path: .meta.router
+      - entry: wippy.facade:theme_persist_endpoint
         path: .meta.router
 
   - name: fe_facade_url
@@ -35,7 +39,7 @@ entries:
     targets:
       - entry: wippy.facade:fe_facade_url
         path: .default
-    default: https://web-host.wippy.ai/webcomponents-1.0.40
+    default: https://web-host.wippy.ai/webcomponents-1.0.41
 
   - name: fe_entry_path
     kind: ns.requirement
@@ -162,6 +166,36 @@ entries:
       - entry: wippy.facade:theme_mode
         path: .default
     default: auto
+
+  - name: theme_persist
+    kind: ns.requirement
+    meta:
+      description: |
+        Where the user's chosen theme mode is persisted across reloads.
+        "none" (default) keeps the current behavior (theme always comes from
+        theme_mode). "cookie" stores it in a cookie — the Jet shell reads it
+        server-side and renders the w-theme-* class before paint (no flash).
+        "localStorage" stores it client-side (a brief flash is unavoidable; the
+        server can't read it). The store name is theme_storage_key. The facade
+        serves a ready-made script at /facade/theme-persist.js that applies and
+        writes the value; the host shell and login/non-host pages just include it.
+    targets:
+      - entry: wippy.facade:theme_persist
+        path: .default
+    default: none
+
+  - name: theme_storage_key
+    kind: ns.requirement
+    meta:
+      description: |
+        Cookie / localStorage key used to persist the theme mode when
+        theme_persist is "cookie" or "localStorage". Returned in /facade/config
+        as themeStorageKey and baked into /facade/theme-persist.js so non-Wippy
+        pages share the same key.
+    targets:
+      - entry: wippy.facade:theme_storage_key
+        path: .default
+    default: "@wippy-theme-mode"
 
   # Auth
   - name: login_path
@@ -380,10 +414,14 @@ entries:
     directory: ./public/
     mode: "0755"
 
+  # Serves facade static assets (@wippy-fe/loading.js) and is the SPA fallback
+  # for history-mode deep links. The Jet shell endpoints below match only the
+  # exact "/" and "/index.html" (Go 1.22 "{$}" = exact match), a strict subset
+  # of this catch-all, so they win for those paths without shadowing assets.
   - name: static
     kind: http.static
     meta:
-      comment: Serves facade index.html
+      comment: Serves facade assets (@wippy-fe/*) + SPA fallback
       server: server
     fs: public_files
     directory: /
@@ -391,6 +429,62 @@ entries:
     options:
       index: index.html
       spa: true
+
+  # Jet-rendered shell (index.html) — server-side theme cookie application
+  # Root router for the Jet shell. Endpoints use exact-match paths ("/{$}" and
+  # "/index.html") so they only intercept those two routes; the /api/public API
+  # router and the "/" static catch-all handle everything else.
+  - name: web_router
+    kind: http.router
+    meta:
+      comment: Root router for the Jet-rendered facade shell
+      server: server
+    prefix: /
+
+  - name: templates
+    kind: template.set
+    meta:
+      comment: Facade Jet template set (shell)
+
+  - name: index
+    kind: template.jet
+    meta:
+      content_type: text/html
+      comment: Facade shell template — conditionally bakes the theme class onto <html>
+    source: file://index.jet
+    set: wippy.facade:templates
+
+  - name: index_handler
+    kind: function.lua
+    meta:
+      comment: Renders the facade shell; applies the persisted theme from the request cookie (cookie mode)
+    source: file://index_handler.lua
+    method: handler
+    modules:
+      - http
+      - registry
+      - templates
+    security:
+      actor:
+        id: wippy.facade:index_handler
+      policies:
+        - wippy.facade:config_read_runtime
+
+  - name: index_endpoint
+    kind: http.endpoint
+    meta:
+      router: web_router
+    method: GET
+    path: /{$}
+    func: index_handler
+
+  - name: index_html_endpoint
+    kind: http.endpoint
+    meta:
+      router: web_router
+    method: GET
+    path: /index.html
+    func: index_handler
 
   # Shared helpers: file:// resolution and CSS variable generation
   - name: theming_helpers
@@ -459,6 +553,31 @@ entries:
     method: GET
     path: /facade/variables.css
     func: css_vars_handler
+
+  # Theme-persistence script endpoint
+  - name: theme_persist_handler
+    kind: function.lua
+    meta:
+      comment: Serves /facade/theme-persist.js — early-apply + window.wippyThemePersist with key/mode baked in
+    source: file://theme_persist_handler.lua
+    method: handler
+    modules:
+      - http
+      - registry
+      - json
+    security:
+      actor:
+        id: wippy.facade:theme_persist_handler
+      policies:
+        - wippy.facade:config_read_runtime
+
+  - name: theme_persist_endpoint
+    kind: http.endpoint
+    meta:
+      router: router
+    method: GET
+    path: /facade/theme-persist.js
+    func: theme_persist_handler
 
   - name: config_read_runtime
     kind: security.policy

--- a/src/facade/_index.yaml
+++ b/src/facade/_index.yaml
@@ -35,7 +35,7 @@ entries:
     targets:
       - entry: wippy.facade:fe_facade_url
         path: .default
-    default: https://web-host.wippy.ai/webcomponents-1.0.39
+    default: https://web-host.wippy.ai/webcomponents-1.0.40
 
   - name: fe_entry_path
     kind: ns.requirement

--- a/src/facade/_index.yaml
+++ b/src/facade/_index.yaml
@@ -354,6 +354,15 @@ entries:
         path: .default
     default: "{}"
 
+  - name: tanstack
+    kind: ns.requirement
+    meta:
+      description: "TanStack Query default options as JSON: { default?, content?, lists? }. `default` applies to every query; `content` targets single-resource renders (page/artifact/session/entry/model/upload), `lists` targets navigation/index queries. Each is a JSON-safe subset of query options (refetchOnWindowFocus, refetchOnReconnect, refetchOnMount, staleTime, gcTime, retry, refetchInterval). Default behavior (no config) is refetchOnWindowFocus:false. e.g. {\"lists\":{\"refetchOnWindowFocus\":true}}"
+    targets:
+      - entry: wippy.facade:tanstack
+        path: .default
+    default: "{}"
+
   - name: extra_scripts
     kind: ns.requirement
     meta:

--- a/src/facade/config_handler.lua
+++ b/src/facade/config_handler.lua
@@ -181,6 +181,9 @@ local function handler()
 
     local axios_defaults = non_empty_map_or_nil(get_req_json_any("axios_defaults"))
     local extra_scripts = non_empty_array_or_nil(get_req_json_any("extra_scripts"))
+    -- TanStack Query defaults: { default?, content?, lists? }. Passed through
+    -- verbatim; the host validates/whitelists the option keys client-side.
+    local tanstack = non_empty_map_or_nil(get_req_json_any("tanstack"))
 
     -- Clamp theme_mode to the valid enum; anything else (typo/misconfig) → auto,
     -- so a bad value can't ship a silently-ignored class to the client.
@@ -207,6 +210,7 @@ local function handler()
         themeMode = theme_mode,
         apiRoutes = api_routes,
         axiosDefaults = axios_defaults,
+        tanstack = tanstack,
         extraScripts = extra_scripts,
         theming = {
             global = global_scope,

--- a/src/facade/config_handler.lua
+++ b/src/facade/config_handler.lua
@@ -192,6 +192,18 @@ local function handler()
         theme_mode = "auto"
     end
 
+    -- Persistence of the chosen theme mode. Clamp to the valid enum (bad value →
+    -- "none" = no persistence). theme_storage_key falls back to the documented
+    -- default so a blank requirement still produces a usable key.
+    local theme_persist = get_req("theme_persist")
+    if theme_persist ~= "cookie" and theme_persist ~= "localStorage" then
+        theme_persist = "none"
+    end
+    local theme_storage_key = get_req("theme_storage_key")
+    if theme_storage_key == "" then
+        theme_storage_key = "@wippy-theme-mode"
+    end
+
     local config = {
         facade_url = facade_url,
         iframe_origin = iframe_origin,
@@ -208,6 +220,8 @@ local function handler()
         },
         routePrefix = non_empty_or_nil(api_url),
         themeMode = theme_mode,
+        themePersist = theme_persist,
+        themeStorageKey = theme_storage_key,
         apiRoutes = api_routes,
         axiosDefaults = axios_defaults,
         tanstack = tanstack,

--- a/src/facade/config_handler_test.lua
+++ b/src/facade/config_handler_test.lua
@@ -17,6 +17,7 @@ local REQ_NAMES: {string} = {
     "api_routes", "additional_nav_items", "state_cache",
     "allow_additional_tags", "chat", "axios_defaults",
     "extra_scripts", "host_config_layout", "theme_mode",
+    "theme_persist", "theme_storage_key",
     "tanstack",
 }
 
@@ -56,6 +57,8 @@ local function setup_registry(overrides: {[string]: string}?)
         extra_scripts = "[]",
         host_config_layout = "{}",
         theme_mode = "auto",
+        theme_persist = "none",
+        theme_storage_key = "@wippy-theme-mode",
         tanstack = "{}",
     }
 
@@ -93,6 +96,23 @@ local function derive_ws_url(api_url: string): string
     return api_url:gsub("^https://", "wss://"):gsub("^http://", "ws://")
 end
 
+-- Mirrors the clamp in config_handler.lua: only "cookie"/"localStorage" are
+-- valid persistence targets; anything else (typo/misconfig) → "none".
+local function clamp_theme_persist(value: string): string
+    if value ~= "cookie" and value ~= "localStorage" then
+        return "none"
+    end
+    return value
+end
+
+-- Mirrors the storage-key fallback: blank requirement → documented default.
+local function clamp_theme_storage_key(value: string): string
+    if value == "" then
+        return "@wippy-theme-mode"
+    end
+    return value
+end
+
 local function define_tests()
     test.describe("config handler", function()
         test.describe("ws url derivation", function()
@@ -113,6 +133,28 @@ local function define_tests()
             end)
         end)
 
+        test.describe("theme persistence clamping", function()
+            test.it("keeps cookie and localStorage as-is", function()
+                test.eq(clamp_theme_persist("cookie"), "cookie")
+                test.eq(clamp_theme_persist("localStorage"), "localStorage")
+            end)
+
+            test.it("clamps unknown / typo values to none", function()
+                test.eq(clamp_theme_persist("none"), "none")
+                test.eq(clamp_theme_persist(""), "none")
+                test.eq(clamp_theme_persist("localstorage"), "none")
+                test.eq(clamp_theme_persist("session"), "none")
+            end)
+
+            test.it("storage key falls back to default when blank", function()
+                test.eq(clamp_theme_storage_key(""), "@wippy-theme-mode")
+            end)
+
+            test.it("storage key keeps a custom value", function()
+                test.eq(clamp_theme_storage_key("my.theme"), "my.theme")
+            end)
+        end)
+
         test.describe("iframe URL construction", function()
             test.it("builds iframe URL from facade_url and entry_path", function()
                 local facade_url = "https://front.wippy.ai"
@@ -123,7 +165,7 @@ local function define_tests()
             end)
 
             test.it("extracts iframe origin from facade URL", function()
-                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.40"
+                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.41"
                 local origin = facade_url:match("^(https?://[^/]+)")
 
                 test.eq(origin, "https://web-host.wippy.ai")
@@ -347,6 +389,8 @@ local function define_tests()
                     },
                     routePrefix = "http://localhost:8085",
                     themeMode = "auto",
+                    themePersist = "cookie",
+                    themeStorageKey = "@wippy-theme-mode",
                     theming = {
                         global = {
                             customCSS = "@import url('https://fonts.example.com');",
@@ -388,6 +432,8 @@ local function define_tests()
                 test.is_false(decoded.hostConfig.allowSelectModel)
                 test.eq(decoded.theming.host.i18n.app.title, "Wippy")
                 test.eq(decoded.themeMode, "auto")
+                test.eq(decoded.themePersist, "cookie")
+                test.eq(decoded.themeStorageKey, "@wippy-theme-mode")
                 test.eq(decoded.login_path, "/login.html")
             end)
         end)

--- a/src/facade/config_handler_test.lua
+++ b/src/facade/config_handler_test.lua
@@ -123,7 +123,7 @@ local function define_tests()
             end)
 
             test.it("extracts iframe origin from facade URL", function()
-                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.39"
+                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.40"
                 local origin = facade_url:match("^(https?://[^/]+)")
 
                 test.eq(origin, "https://web-host.wippy.ai")

--- a/src/facade/config_handler_test.lua
+++ b/src/facade/config_handler_test.lua
@@ -17,6 +17,7 @@ local REQ_NAMES: {string} = {
     "api_routes", "additional_nav_items", "state_cache",
     "allow_additional_tags", "chat", "axios_defaults",
     "extra_scripts", "host_config_layout", "theme_mode",
+    "tanstack",
 }
 
 local function setup_registry(overrides: {[string]: string}?)
@@ -55,6 +56,7 @@ local function setup_registry(overrides: {[string]: string}?)
         extra_scripts = "[]",
         host_config_layout = "{}",
         theme_mode = "auto",
+        tanstack = "{}",
     }
 
     if overrides then
@@ -238,6 +240,32 @@ local function define_tests()
                 test.eq(decoded.layouts.default.direction, "vertical")
                 test.eq(decoded.panels.main.kind, "page")
                 test.eq(decoded.panels.main.id, "home")
+            end)
+
+            test.it("tanstack requirement defaults to empty JSON object", function()
+                local entry = registry.get(NS .. "tanstack")
+                test.not_nil(entry)
+                test.eq(entry.data.default, "{}")
+            end)
+
+            test.it("tanstack decodes a valid per-category config JSON", function()
+                local tanstack_json = '{"default":{"staleTime":30000},"content":{"refetchOnWindowFocus":false},"lists":{"refetchOnWindowFocus":true}}'
+                local snap = registry.snapshot()
+                local changes = snap:changes()
+                changes:update({
+                    id = NS .. "tanstack",
+                    kind = "ns.requirement",
+                    data = { default = tanstack_json },
+                })
+                changes:apply()
+
+                local entry = registry.get(NS .. "tanstack")
+                local decoded, err = json.decode(entry.data.default :: string)
+                test.is_nil(err)
+                test.not_nil(decoded)
+                test.eq(decoded.default.staleTime, 30000)
+                test.is_false(decoded.content.refetchOnWindowFocus)
+                test.is_true(decoded.lists.refetchOnWindowFocus)
             end)
         end)
 

--- a/src/facade/index.jet
+++ b/src/facade/index.jet
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en"{{ if hasTheme }} class="{{ themeClass }}" style="color-scheme: {{ colorScheme }};"{{ end }}>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="color-scheme" content="light dark">
-    <!-- Theme persistence (client-side): applies the stored theme before paint
-         and exposes window.wippyThemePersist. This file is the SPA fallback for
-         history-mode deep links; the Jet shell (index.jet) is identical plus a
-         server-rendered <html> theme class for cookie mode. Keep the two in sync. -->
+    <!-- Theme persistence: applies the stored theme class before paint and exposes
+         window.wippyThemePersist. Render-blocking and first so there's no flash.
+         In cookie mode the server already set the class on <html> above. -->
     <script src="/api/public/facade/theme-persist.js"></script>
     <title>Wippy</title>
     <script src="/@wippy-fe/loading.js"></script>

--- a/src/facade/index_handler.lua
+++ b/src/facade/index_handler.lua
@@ -1,0 +1,86 @@
+local http = require("http")
+local registry = require("registry")
+local templates = require("templates")
+
+local NS = "wippy.facade:"
+local TEMPLATE_SET = NS .. "templates"
+
+local function get_req(name: string): string
+    local entry, _ = registry.get(NS .. name)
+    if entry and entry.data then
+        return entry.data.default or ""
+    end
+    return ""
+end
+
+-- Pull a single cookie value out of the raw Cookie header
+-- ("a=1; @wippy-theme-mode=dark; b=2" → "dark"). Plain string match — no
+-- pattern metachars from `name` reach gsub (we compare with ==).
+local function cookie_value(header: string?, name: string): string?
+    if not header or header == "" then
+        return nil
+    end
+    for pair in header:gmatch("[^;]+") do
+        local k, v = pair:match("^%s*(.-)%s*=%s*(.*)$")
+        if k == name then
+            return v
+        end
+    end
+    return nil
+end
+
+-- Renders the facade shell (index.jet). The only server-side dynamic part is the
+-- theme: in "cookie" persistence mode the stored mode is read from the request
+-- cookie and the matching w-theme-* class is baked onto <html> so the very first
+-- paint is already themed (no flash). "localStorage"/"none" render no class — the
+-- served theme-persist.js handles those client-side.
+local function handler()
+    local req = http.request()
+    local res = http.response()
+    if not res then
+        return nil, "no HTTP context"
+    end
+
+    local persist = get_req("theme_persist")
+    local key = get_req("theme_storage_key")
+    if key == "" then
+        key = "@wippy-theme-mode"
+    end
+
+    local has_theme = false
+    local theme_class = ""
+    local color_scheme = ""
+    if persist == "cookie" and req then
+        local stored = cookie_value(req:header("Cookie"), key)
+        if stored == "dark" then
+            has_theme = true
+            theme_class = "w-theme-dark"
+            color_scheme = "dark"
+        elseif stored == "light" then
+            has_theme = true
+            theme_class = "w-theme-light"
+            color_scheme = "light"
+        end
+    end
+
+    local set = templates.get(TEMPLATE_SET)
+    local html, err = set:render("index", {
+        hasTheme = has_theme,
+        themeClass = theme_class,
+        colorScheme = color_scheme,
+    })
+    if err then
+        res:set_status(http.STATUS.INTERNAL_SERVER_ERROR)
+        res:set_content_type("text/html")
+        res:write("<!doctype html><meta charset=\"utf-8\"><title>Wippy</title>Failed to render shell.")
+        return nil, err
+    end
+
+    res:set_content_type("text/html")
+    -- The shell embeds a per-user theme from a cookie; never cache across users.
+    res:set_header("Cache-Control", "no-store")
+    res:set_status(http.STATUS.OK)
+    res:write(html)
+end
+
+return { handler = handler }

--- a/src/facade/theme_persist_handler.lua
+++ b/src/facade/theme_persist_handler.lua
@@ -1,0 +1,91 @@
+local http = require("http")
+local registry = require("registry")
+local json = require("json")
+
+local NS = "wippy.facade:"
+
+local function get_req(name: string): string
+    local entry, _ = registry.get(NS .. name)
+    if entry and entry.data then
+        return entry.data.default or ""
+    end
+    return ""
+end
+
+-- Body of the served script, minus the first line which injects KEY/MODE.
+-- Long-bracket string so the regex backslashes need no Lua escaping.
+local BODY = [==[
+  function read() {
+    if (MODE === 'none') return null;
+    try {
+      if (MODE === 'cookie') {
+        var k = KEY.replace(/[.$?*|{}()[\]\\/+^]/g, '\\$&');
+        var m = document.cookie.match(new RegExp('(?:^|; )' + k + '=([^;]*)'));
+        return m ? decodeURIComponent(m[1]) : null;
+      }
+      return localStorage.getItem(KEY);
+    } catch (e) { return null; }
+  }
+  function apply(v) {
+    var el = document.documentElement;
+    el.classList.toggle('w-theme-dark', v === 'dark');
+    el.classList.toggle('w-theme-light', v === 'light');
+    if (v === 'dark' || v === 'light') el.style.colorScheme = v;
+    else el.style.removeProperty('color-scheme');
+  }
+  function write(mode) {
+    if (MODE === 'none') return;
+    try {
+      if (MODE === 'cookie')
+        document.cookie = KEY + '=' + encodeURIComponent(mode) + '; path=/; max-age=31536000; SameSite=Lax';
+      else localStorage.setItem(KEY, mode);
+    } catch (e) {}
+  }
+  var v = read();
+  if (v === 'dark' || v === 'light') apply(v);
+  window.wippyThemePersist = { mode: MODE, key: KEY, read: read, write: write, apply: apply };
+})();
+]==]
+
+-- Serves /facade/theme-persist.js: a tiny, ready-to-include script with the
+-- configured storage KEY and MODE baked in. On load it applies the stored
+-- theme class (early-apply) and exposes `window.wippyThemePersist` with
+-- read/write/apply helpers. The host shell, login pages and arbitrary
+-- non-Wippy pages integrate with a single <script src> — no config object,
+-- and the facade stays the single source of truth for the key + storage logic.
+local function handler()
+    local res = http.response()
+    if not res then
+        return nil, "no HTTP context"
+    end
+
+    -- Clamp the same way config_handler does, so the script and /facade/config
+    -- always agree on the effective mode/key.
+    local mode = get_req("theme_persist")
+    if mode ~= "cookie" and mode ~= "localStorage" then
+        mode = "none"
+    end
+    local key = get_req("theme_storage_key")
+    if key == "" then
+        key = "@wippy-theme-mode"
+    end
+
+    -- json.encode produces a safe double-quoted JS string literal for both values.
+    local key_lit, kerr = json.encode(key)
+    if kerr then
+        key_lit = '"@wippy-theme-mode"'
+    end
+    local mode_lit, merr = json.encode(mode)
+    if merr then
+        mode_lit = '"none"'
+    end
+
+    local js = "(function () {\n  var KEY = " .. key_lit .. ", MODE = " .. mode_lit .. ";\n" .. BODY
+
+    res:set_content_type("application/javascript")
+    res:set_header("Cache-Control", "public, max-age=3600")
+    res:set_status(http.STATUS.OK)
+    res:write(js)
+end
+
+return { handler = handler }


### PR DESCRIPTION
## EE2-2265 — facade `tanstack` param + CDN 1.0.40

Rebased onto current `master` (preserves the strict security policies from `9d624bc` / `f01b29d`). Adds, on top:

- **`tanstack` requirement** (default `{}`) → `config_handler` returns it as **top-level `tanstack`** in `/api/public/facade/config` (`{ default?, content?, lists? }` — global + per-role TanStack Query defaults). Mirrors the `api_routes` / `axios_defaults` JSON-requirement pattern.
- **Web Host CDN ref `1.0.39` → `1.0.40`** (`_index.yaml` `fe_facade_url` default, `Makefile`, `README`, `config_handler_test`).
- README + a `config_handler_test` case for the tanstack decode.

## EE2-2274 — theme persistence (cookie / localStorage / none) + Jet SSR shell

Facade-owned theme persistence; the Web Host stays persist-agnostic (it only emits a new `themeChanged` event). Published as **`wippy/facade@0.6.17`**.

- **Config:** two new requirements surfaced via `/api/public/facade/config` — `theme_persist` (`none` default | `cookie` | `localStorage`) → `themePersist`; `theme_storage_key` (default `@wippy-theme-mode`) → `themeStorageKey`. Clamped (unknown value → `none`, empty key → default) with `config_handler_test` coverage.
- **Generated snippet:** `theme_persist_handler.lua` serves `GET /facade/theme-persist.js` (`application/javascript`) with KEY/MODE baked in — early-applies the `w-theme-*` class from storage and exposes `window.wippyThemePersist { mode, key, read, write, apply }`. One render-blocking `<script src>` integrates any page, including non-Wippy-hosted ones.
- **Jet SSR shell:** `index.jet` + `index_handler.lua` read the theme cookie server-side and bake `class="w-theme-dark"` / `color-scheme` onto `<html>` for zero-flash in cookie mode, and seed the persisted value into `initWippyApp`. The host applies it via the existing `applyThemeMode` — no host persist logic.
- **CDN ref `1.0.40` → `1.0.41`** (`_index.yaml` `fe_facade_url`, `Makefile`, `README`, `config_handler_test`).

