### PR TITLE
fix(views): sort unnamed components safely

### DIFF
--- a/src/views/component_registry.lua
+++ b/src/views/component_registry.lua
@@ -74,7 +74,14 @@ function components.find_all()
     end
 
     table.sort(components_list, function(a, b)
-        return a.name < b.name
+        -- Names are optional because bundled metadata can provide them later.
+        -- Keep the projection raw while making discovery safe and stable.
+        local a_name = type(a.name) == "string" and a.name or ""
+        local b_name = type(b.name) == "string" and b.name or ""
+        if a_name == b_name then
+            return tostring(a.id) < tostring(b.id)
+        end
+        return a_name < b_name
     end)
 
     return components_list

--- a/src/views/component_registry_test.lua
+++ b/src/views/component_registry_test.lua
@@ -10,7 +10,7 @@ local PAGE_IDS = {
 }
 
 local COMPONENT_IDS = {
-    "test_comp_widget", "test_comp_chart", "test_comp_custom_entry",
+    "test_comp_widget", "test_comp_chart", "test_comp_custom_entry", "test_comp_unnamed",
 }
 
 local function setup_pages()
@@ -128,6 +128,20 @@ local function setup_components()
         },
     })
 
+    changes:create({
+        id = NS .. "test_comp_unnamed",
+        kind = "registry.entry",
+        meta = {
+            type = "view.component",
+            title = "Unnamed",
+            secure = false,
+            public = true,
+            announced = true,
+            tag_name = "test-unnamed",
+            url = "https://cdn.example.com/unnamed/",
+        },
+    })
+
     changes:apply()
 end
 
@@ -165,7 +179,7 @@ local function define_tests()
                     count = count + 1
                 end
             end
-            test.eq(count, 3)
+            test.eq(count, 4)
         end)
 
         test.it("find_all does not include view.page entries", function()
@@ -252,7 +266,7 @@ local function define_tests()
 
             local test_comps = {}
             for _, comp in ipairs(components) do
-                if comp.id:find("^" .. NS .. "test_comp") then
+                if comp.id:find("^" .. NS .. "test_comp") and comp.name then
                     table.insert(test_comps, comp)
                 end
             end
@@ -260,6 +274,23 @@ local function define_tests()
             for i = 1, #test_comps - 1 do
                 test.is_true(test_comps[i].name <= test_comps[i + 1].name)
             end
+        end)
+
+        test.it("find_all accepts components without meta.name", function()
+            local components, err = component_registry.find_all()
+            test.is_nil(err)
+
+            local unnamed: any = nil
+            for _, comp in ipairs(components) do
+                if comp.id == NS .. "test_comp_unnamed" then
+                    unnamed = comp
+                    break
+                end
+            end
+
+            test.not_nil(unnamed)
+            test.is_nil(unnamed.name)
+            test.eq(unnamed.tag_name, "test-unnamed")
         end)
     end)
 end

--- a/src/views/test/_index.yaml
+++ b/src/views/test/_index.yaml
@@ -77,3 +77,18 @@ entries:
       inline: false
     source: file://test_tmpl_settings.jet
     set: test_templates
+
+  # Package test entries are excluded from the runtime projection. Keep this
+  # executable regression in the harness that consumes the package.
+  - name: component_registry_test
+    kind: function.lua
+    meta:
+      type: test
+      suite: views
+    source: file://component_registry_regression_test.lua
+    method: run
+    imports:
+      test: wippy.test:test
+      component_registry: wippy.views:component_registry
+    modules:
+      - registry

--- a/src/views/test/component_registry_regression_test.lua
+++ b/src/views/test/component_registry_regression_test.lua
@@ -1,0 +1,62 @@
+local test = require("test")
+local registry = require("registry")
+local component_registry = require("component_registry")
+
+local ENTRY_IDS = {
+    "app:test_component_without_name_b",
+    "app:test_component_without_name_a",
+}
+
+local function remove_fixtures()
+    local snap = registry.snapshot()
+    local changes = snap:changes()
+    for _, id in ipairs(ENTRY_IDS) do
+        changes:delete(id)
+    end
+    changes:apply()
+end
+
+local function define_tests()
+    test.describe("component registry regressions", function()
+        test.after_each(remove_fixtures)
+
+        test.it("lists unnamed view components in deterministic id order", function()
+            local snap = registry.snapshot()
+            local changes = snap:changes()
+            for _, id in ipairs(ENTRY_IDS) do
+                changes:create({
+                    id = id,
+                    kind = "registry.entry",
+                    meta = {
+                        type = "view.component",
+                        title = "Unnamed component",
+                        tag_name = id:gsub(":", "-"),
+                        announced = true,
+                        auto_register = true,
+                    },
+                })
+            end
+            changes:apply()
+
+            local components, err = component_registry.find_all()
+            test.is_nil(err)
+
+            local found = {}
+            for _, component in ipairs(components) do
+                if component.id == ENTRY_IDS[1] or component.id == ENTRY_IDS[2] then
+                    table.insert(found, component)
+                end
+            end
+
+            test.eq(#found, 2)
+            test.eq(found[1].id, ENTRY_IDS[2])
+            test.eq(found[2].id, ENTRY_IDS[1])
+            test.is_nil(found[1].name)
+            test.is_nil(found[2].name)
+        end)
+    end)
+end
+
+return {
+    run = test.run_cases(define_tests),
+}


### PR DESCRIPTION
## Summary

- keep optional component names unset so bundled metadata can supply them
- sort discovery results with a nil-safe name key and deterministic ID tie-break
- add package and executable harness regressions for nameless components

## Verification

- `cd src/views && wippy lint` — 19 entries
- `cd src/views/test && wippy lint` — 19 entries
- `cd src/views/test && wippy run test` — 1/1
- live Kickside authenticated component autoload — HTTP 200, 34 components