### PR TITLE
fix(relay): declare process upgrade policy

### DIFF
--- a/src/relay/src/central.lua
+++ b/src/relay/src/central.lua
@@ -233,7 +233,7 @@ local function run(): any
     }
 
     process.registry.register(consts.CENTRAL_HUB_REGISTRY_NAME)
-    process.set_options({ trap_links = true })
+    process.set_options({ trap_links = true, upgradable = false })
 
     local gc_ticker = time.ticker(config.gc_check_interval)
     local inbox = process.inbox()

--- a/src/relay/src/user.lua
+++ b/src/relay/src/user.lua
@@ -401,7 +401,7 @@ local function run(args: any): any
         error("Failed to register user hub " .. registry_name .. ": " .. (register_err or "unknown error"))
     end
     logger:info("user hub registered", { user_id = state.user_id, registry_name = registry_name })
-    process.set_options({ trap_links = true })
+    process.set_options({ trap_links = true, upgradable = false })
 
     for prefix, plugin_config in pairs(state.plugins) do
         if plugin_config.auto_start then


### PR DESCRIPTION
Declare the required non-upgradable process option explicitly for both Relay hubs. This restores the current runtime API contract without changing behavior.\n\nVerification: Relay lint passes (10 entries); Relay test command exits cleanly.