### PR TITLE
fix(ci): require publish-scoped token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,25 +82,10 @@ jobs:
       - name: Authenticate to Wippy Hub
         env:
           WIPPY_PUBLISH_TOKEN: ${{ secrets.WIPPY_PUBLISH_TOKEN }}
-          WIPPY_USERNAME: ${{ secrets.WIPPY_USERNAME }}
-          WIPPY_PASSWORD: ${{ secrets.WIPPY_PASSWORD }}
         run: |
           set -euo pipefail
-          if [[ -n "$WIPPY_PUBLISH_TOKEN" ]] && \
-             wippy auth login --local --token "$WIPPY_PUBLISH_TOKEN"; then
-            exit 0
-          fi
-
-          test -n "$WIPPY_USERNAME"
-          test -n "$WIPPY_PASSWORD"
-          response="$(curl -fsSL -X POST \
-            https://keycloak.wippy.ai/realms/wippy/protocol/openid-connect/token \
-            --data-urlencode grant_type=password \
-            --data-urlencode client_id=wippy-app \
-            --data-urlencode username="$WIPPY_USERNAME" \
-            --data-urlencode password="$WIPPY_PASSWORD")"
-          access_token="$(jq -er '.access_token' <<<"$response")"
-          wippy auth login --local --token "$access_token"
+          test -n "$WIPPY_PUBLISH_TOKEN"
+          wippy auth login --local --token "$WIPPY_PUBLISH_TOKEN"
 
       - name: Validate package
         env:


### PR DESCRIPTION
Remove the rejected legacy username/password fallback. Framework module publishing now has one supported credential path: a masked publish-scoped Wippy Hub token.