### PR TITLE
chore(facade): bump default Web Host CDN pin 1.0.42 -> 1.0.43 [EE2-2309]

### DIFF
--- a/src/facade/Makefile
+++ b/src/facade/Makefile
@@ -6,7 +6,7 @@
 # Run `make sync` after every Wippy Web Host version bump to pull fresh copies.
 
 # Web Host CDN base — update version when Wippy Web Host releases
-WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.42
+WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.43
 
 # Files to sync from CDN into public/@wippy-fe/
 CDN_FILES = loading.js

--- a/src/facade/README.md
+++ b/src/facade/README.md
@@ -66,7 +66,7 @@ These fields are NOT configurable via requirements — they are computed at runt
 
 | Requirement | Default | Description |
 |---|---|---|
-| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.42` | CDN base URL for the Web Host frontend bundle |
+| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.43` | CDN base URL for the Web Host frontend bundle |
 | `fe_entry_path` | `/iframe.html` | Iframe HTML entry point path (appended to `fe_facade_url`) |
 | `fe_mode` | `compat` | `compat` (default — loads `module.js`) or `managed` (loads `managed-layout.js` for declarative multi-panel apps). See [Modes](#modes) above |
 
@@ -377,9 +377,9 @@ Returns an empty body (200 OK) when no variables are configured. Response has `C
 
 ```json
 {
-  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.42",
+  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.43",
   "iframe_origin": "https://web-host.wippy.ai",
-  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.42/iframe.html?waitForCustomConfig",
+  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.43/iframe.html?waitForCustomConfig",
   "login_path": "/login.html",
   "login_redirect_param": null,
   "env": {

--- a/src/facade/_index.yaml
+++ b/src/facade/_index.yaml
@@ -39,7 +39,7 @@ entries:
     targets:
       - entry: wippy.facade:fe_facade_url
         path: .default
-    default: https://web-host.wippy.ai/webcomponents-1.0.42
+    default: https://web-host.wippy.ai/webcomponents-1.0.43
 
   - name: fe_entry_path
     kind: ns.requirement

--- a/src/facade/config_handler_test.lua
+++ b/src/facade/config_handler_test.lua
@@ -165,7 +165,7 @@ local function define_tests()
             end)
 
             test.it("extracts iframe origin from facade URL", function()
-                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.42"
+                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.43"
                 local origin = facade_url:match("^(https?://[^/]+)")
 
                 test.eq(origin, "https://web-host.wippy.ai")


### PR DESCRIPTION
Bumps the facade default Web Host CDN pin `webcomponents-1.0.42` -> `webcomponents-1.0.43` in the four `src/facade/` sources: `_index.yaml` (`fe_facade_url` default), `Makefile` (`WEB_HOST_CDN`), `README.md`, and `config_handler_test.lua`.

Published to the hub as `wippy/facade@0.6.22`. Part of EE2-2309 (facade custom CSS -> `view.component` shadow roots, shipped in Web Host 1.0.43 / `@wippy-fe` 0.0.43).

Ref: https://jira.spiralscout.com/browse/EE2-2309