### PR TITLE
chore(facade): Web Host CDN pin -> 1.0.44 (facade 0.6.23) [EE2-2307]

### DIFF
--- a/src/facade/Makefile
+++ b/src/facade/Makefile
@@ -6,7 +6,7 @@
 # Run `make sync` after every Wippy Web Host version bump to pull fresh copies.
 
 # Web Host CDN base — update version when Wippy Web Host releases
-WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.43
+WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.44
 
 # Files to sync from CDN into public/@wippy-fe/
 CDN_FILES = loading.js

--- a/src/facade/README.md
+++ b/src/facade/README.md
@@ -66,7 +66,7 @@ These fields are NOT configurable via requirements — they are computed at runt
 
 | Requirement | Default | Description |
 |---|---|---|
-| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.43` | CDN base URL for the Web Host frontend bundle |
+| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.44` | CDN base URL for the Web Host frontend bundle |
 | `fe_entry_path` | `/iframe.html` | Iframe HTML entry point path (appended to `fe_facade_url`) |
 | `fe_mode` | `compat` | `compat` (default — loads `module.js`) or `managed` (loads `managed-layout.js` for declarative multi-panel apps). See [Modes](#modes) above |
 
@@ -377,9 +377,9 @@ Returns an empty body (200 OK) when no variables are configured. Response has `C
 
 ```json
 {
-  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.43",
+  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.44",
   "iframe_origin": "https://web-host.wippy.ai",
-  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.43/iframe.html?waitForCustomConfig",
+  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.44/iframe.html?waitForCustomConfig",
   "login_path": "/login.html",
   "login_redirect_param": null,
   "env": {

--- a/src/facade/_index.yaml
+++ b/src/facade/_index.yaml
@@ -39,7 +39,7 @@ entries:
     targets:
       - entry: wippy.facade:fe_facade_url
         path: .default
-    default: https://web-host.wippy.ai/webcomponents-1.0.43
+    default: https://web-host.wippy.ai/webcomponents-1.0.44
 
   - name: fe_entry_path
     kind: ns.requirement

--- a/src/facade/config_handler_test.lua
+++ b/src/facade/config_handler_test.lua
@@ -165,7 +165,7 @@ local function define_tests()
             end)
 
             test.it("extracts iframe origin from facade URL", function()
-                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.43"
+                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.44"
                 local origin = facade_url:match("^(https?://[^/]+)")
 
                 test.eq(origin, "https://web-host.wippy.ai")


### PR DESCRIPTION
Bumps the facade default `fe_facade_url` to Web Host **1.0.44** (published facade **0.6.23**).

Web Host 1.0.44 ships:
- **PrimeVue overlays in web components: unclipped + correctly positioned.** The shared `primevue/portal` now teleports overlays to a per-shadow-root anchor that is *measured and pinned* to the true viewport origin — so they stay in the shadow root (theme CSS applies), aren't clipped by a scrolling `Dialog`/`Drawer` body, and land at the trigger even under a transformed ancestor (`translateZ(0)`) or a scrolled window. Fixes the 1.0.42–1.0.43 regression (which defaulted `appendTo='self'` → inline + clipped).
- **`.p-hidden-accessible` sr-only fix** — the `theme: 'none'` base CSS was missing PrimeVue's visually-hidden utility, so accessibility text (e.g. a Select's "No selected item" announcer) rendered visibly.

Verified across all four smoke gates: built host (local), consumer-vs-local-npm, replace-mode (only 1.0.44 on the wire), and fully-published non-dev boot.