### PR TITLE
fix(facade): grant template.get so the shell renders under the strict-security sandbox

### DIFF
--- a/src/facade/_index.yaml
+++ b/src/facade/_index.yaml
@@ -620,7 +620,7 @@ entries:
   - name: config_read_runtime
     kind: security.policy
     meta:
-      comment: Facade handlers read their own declarative config and public API URL.
+      comment: Facade handlers read their own declarative config and public API URL, and load their own Jet template set (the shell).
     policy:
       resources:
         - wippy.facade:*
@@ -628,6 +628,7 @@ entries:
       actions:
         - registry.get
         - env.get
+        - template.get
       effect: allow
 
   - name: content_fs_runtime

--- a/src/facade/test/security_policy_test.lua
+++ b/src/facade/test/security_policy_test.lua
@@ -25,6 +25,8 @@ local function run()
             test.eq(decision("wippy.facade:config_read_runtime", "env.get", "PUBLIC_API_URL"), "allow")
             test.eq(decision("wippy.facade:config_read_runtime", "env.get", "ENCRYPTION_KEY"), "undefined")
             test.eq(decision("wippy.facade:config_read_runtime", "registry.apply", "wippy.facade:fe_facade_url"), "undefined")
+            -- index_handler loads its Jet shell via templates.get, gated on template.get
+            test.eq(decision("wippy.facade:config_read_runtime", "template.get", "wippy.facade:templates"), "allow")
         end)
 
         test.it("grants only filesystem open for fs-backed theming", function()


### PR DESCRIPTION
## Symptom
GET / on any app using facade >= the strict-security release 500s: `wippy.facade:index_handler:67: attempt to index a non-table object(nil) with key 'render'`.

## Cause
`9d624bc "Add facade strict security policies"` sandboxed `index_handler` under `config_read_runtime` (grants `registry.get` + `env.get`). But the handler loads its Jet shell via `templates.get("wippy.facade:templates")`, which the runtime gates on the **`template.get`** action (`runtime/lua/modules/template/module.go:78`) — not in the policy. Under the sandbox the call is denied and returns nil, so `set:render` indexes nil. A per-entry `security:` block is a *complete* context, enforced regardless of `security.strict_mode`, so this bites every app, not just strict-mode ones.

## Fix
Add `template.get` to `config_read_runtime` (resource stays `wippy.facade:*`; the set is the facade's own resource) + a regression assertion in security_policy_test. Audited all four sandboxed handlers — the other three (config/css_vars/theme_persist) fully cover their gated calls (registry.get, env.get, fs.get) already; index_handler's `template.get` was the only gap. Published as wippy/facade@0.6.24.