### PR TITLE
fix(relay): grant process.send to user hubs via user_security_scope

### DIFF
--- a/src/relay/src/_index.yaml
+++ b/src/relay/src/_index.yaml
@@ -49,6 +49,8 @@ entries:
         path: ".default"
       - entry: wippy.relay.security:user_hub_registry
         path: ".groups +="
+      - entry: wippy.relay.security:user_hub_messaging
+        path: ".groups +="
 
   - name: max_connections_per_user
     kind: ns.requirement

--- a/src/relay/src/security/_index.yaml
+++ b/src/relay/src/security/_index.yaml
@@ -33,4 +33,17 @@ entries:
         - process.registry.register
         - process.registry.unregister
       effect: allow
+
+  # wippy.relay.security:user_hub_messaging
+  - name: user_hub_messaging
+    kind: security.policy
+    meta:
+      comment: User-scoped hub processes deliver payloads to client pids. process.send is checked against the raw destination pid, which has no matchable pattern.
+    groups: []
+    policy:
+      resources:
+        - '*'
+      actions:
+        - process.send
+      effect: allow
     

--- a/src/relay/test/_index.yaml
+++ b/src/relay/test/_index.yaml
@@ -6,15 +6,3 @@ entries:
     kind: registry.entry
     meta:
       comment: Policy group for user relay hubs under test
-
-  - name: user.messaging
-    kind: security.policy
-    meta:
-      comment: Lets user-scoped hub processes message clients during tests
-    groups:
-      - app:user
-    policy:
-      resources: '*'
-      actions:
-        - process.send
-      effect: allow


### PR DESCRIPTION
The user hub delivers welcome and relay payloads with `process.send` under the user actor, but `user_security_scope` only fed `user_hub_registry` (registry register/unregister) — so every hub-to-client delivery was silently denied unless the application hand-rolled a messaging policy (the hub code drops the send result, so nothing surfaces). Found via the relay welcome test in #87, which was temporarily green only because the harness carried a local grant.

Adds `wippy.relay.security:user_hub_messaging` (actions: `process.send`, resources `'*'` — the check runs against the raw destination pid, which has no matchable pattern) and binds `user_security_scope` into its groups alongside the registry policy. The harness drops its local copy, so the relay suite now proves the module's own grant.