### PR TITLE
fix(test): classify runner for wippy test

### DIFF
--- a/src/test/_index.yaml
+++ b/src/test/_index.yaml
@@ -69,6 +69,7 @@ entries:
       command:
         name: test
         short: Run tests
+        use_case: test
     source: file://runner.lua
     method: main
     modules:


### PR DESCRIPTION
Adds the command use-case metadata required by the current CLI so the published test runner is discoverable through the wippy test command. Runtime already owns and tests command selection semantics; this corrects the framework package declaration.