### PR TITLE
fix(packages): declare framework module types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
     branches: [master]
 
 jobs:
+  manifests:
+    name: Module manifests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python3 scripts/check_module_manifests.py
+
   lint:
     name: Lint (${{ matrix.module }})
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PACKAGES_SRC = actor agent bootloader llm relay usage
 # Modules that have test directories with wippy.lock
 TEST_MODULES = actor bootloader embeddings facade llm migration relay usage views
 
-.PHONY: help run-tests run-lint install publish-all \
+.PHONY: help check-manifests run-tests run-lint install publish-all \
 	publish-flat-% publish-src-%
 
 help:
@@ -17,8 +17,12 @@ help:
 	@echo "Usage:"
 	@echo "  make run-tests      Run tests for all modules"
 	@echo "  make run-lint       Run lint for all modules"
+	@echo "  make check-manifests Validate package and test-app module types"
 	@echo "  make install        Install dependencies for all test modules"
 	@echo "  make publish-all    Publish all packages (skips unchanged)"
+
+check-manifests:
+	@python3 scripts/check_module_manifests.py
 
 run-tests:
 	@failed=0; \
@@ -57,7 +61,7 @@ install:
 		(cd src/$$mod/test && wippy install 2>&1 | tail -1); \
 	done
 
-publish-all:
+publish-all: check-manifests
 	@for pkg in $(PACKAGES_FLAT); do \
 		echo "Publishing $$pkg..."; \
 		cd src/$$pkg && wippy publish || echo "$$pkg unchanged or failed"; \

--- a/scripts/check_module_manifests.py
+++ b/scripts/check_module_manifests.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Require explicit package types for every Framework module and test app."""
+
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def scalar(path: Path, field: str) -> str | None:
+    pattern = re.compile(rf"^{re.escape(field)}:\s*([^#\s]+)", re.MULTILINE)
+    match = pattern.search(path.read_text())
+    return match.group(1).strip("'\"") if match else None
+
+
+def main() -> int:
+    errors: list[str] = []
+    manifests = sorted((ROOT / "src").glob("*/wippy.yaml"))
+    manifests += sorted((ROOT / "src").glob("*/src/wippy.yaml"))
+    test_manifests = sorted((ROOT / "src").glob("*/test/wippy.yaml"))
+
+    for path in manifests:
+        if scalar(path, "type") != "library":
+            errors.append(f"{path.relative_to(ROOT)}: Framework packages must declare type: library")
+        if scalar(path, "version") is not None:
+            errors.append(f"{path.relative_to(ROOT)}: Hub selects package versions")
+    for path in test_manifests:
+        if scalar(path, "type") != "application":
+            errors.append(f"{path.relative_to(ROOT)}: test harnesses must declare type: application")
+
+    if errors:
+        print("Module manifest conventions failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print(f"Module manifest conventions passed: {len(manifests)} libraries; {len(test_manifests)} test applications.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/actor/src/wippy.yaml
+++ b/src/actor/src/wippy.yaml
@@ -1,5 +1,6 @@
 organization: wippy
 module: actor
+type: library
 description: Actor pattern library for message-passing concurrency
 license: Apache-2.0
 repository: https://github.com/wippyai/framework

--- a/src/actor/test/wippy.yaml
+++ b/src/actor/test/wippy.yaml
@@ -1,3 +1,4 @@
 organization: wippy
 module: actor-test
+type: application
 description: Test stub for actor module

--- a/src/agent/src/wippy.yaml
+++ b/src/agent/src/wippy.yaml
@@ -1,5 +1,6 @@
 organization: wippy
 module: agent
+type: library
 description: LLM agent framework with tool support and conversation management
 license: Apache-2.0
 repository: https://github.com/wippyai/framework

--- a/src/bootloader/src/wippy.yaml
+++ b/src/bootloader/src/wippy.yaml
@@ -1,5 +1,6 @@
 organization: wippy
 module: bootloader
+type: library
 description: Application bootloader and initialization orchestrator
 license: Apache-2.0
 repository: https://github.com/wippyai/framework

--- a/src/bootloader/test/wippy.yaml
+++ b/src/bootloader/test/wippy.yaml
@@ -1,3 +1,4 @@
 organization: wippy
 module: bootloader-test
+type: application
 description: Test stub for bootloader module

--- a/src/docs/wippy.yaml
+++ b/src/docs/wippy.yaml
@@ -1,5 +1,6 @@
 organization: wippy
 module: docs
+type: library
 description: Module specifications and documentation
 license: Apache-2.0
 repository: https://github.com/wippyai/framework

--- a/src/embeddings/test/wippy.yaml
+++ b/src/embeddings/test/wippy.yaml
@@ -1,3 +1,4 @@
 organization: wippy
 module: embeddings-test
+type: application
 description: Test stub for embeddings module

--- a/src/embeddings/wippy.yaml
+++ b/src/embeddings/wippy.yaml
@@ -1,5 +1,6 @@
 organization: wippy
 module: embeddings
+type: library
 description: Vector embeddings storage and similarity search
 license: Apache-2.0
 repository: https://github.com/wippyai/framework

--- a/src/facade/test/wippy.yaml
+++ b/src/facade/test/wippy.yaml
@@ -1,3 +1,4 @@
 organization: wippy
 module: facade-test
+type: application
 description: Test stub for facade module

--- a/src/facade/wippy.yaml
+++ b/src/facade/wippy.yaml
@@ -1,5 +1,6 @@
 organization: wippy
 module: facade
+type: library
 description: Portable iframe facade for Wippy frontend
 license: Apache-2.0
 repository: https://github.com/wippyai/framework

--- a/src/llm/src/wippy.yaml
+++ b/src/llm/src/wippy.yaml
@@ -1,5 +1,6 @@
 organization: wippy
 module: llm
+type: library
 description: LLM integration library with multi-provider support
 license: Apache-2.0
 repository: https://github.com/wippyai/framework

--- a/src/llm/test/wippy.yaml
+++ b/src/llm/test/wippy.yaml
@@ -1,5 +1,6 @@
 organization: wippy
 module: llm-test
+type: application
 description: Test stub for llm module
 exclude_meta:
   type:

--- a/src/migration/test/wippy.yaml
+++ b/src/migration/test/wippy.yaml
@@ -1,3 +1,4 @@
 organization: wippy
 module: migration-test
+type: application
 description: Test stub for migration module

--- a/src/migration/wippy.yaml
+++ b/src/migration/wippy.yaml
@@ -1,5 +1,6 @@
 organization: wippy
 module: migration
+type: library
 description: Database migration framework
 license: Apache-2.0
 repository: https://github.com/wippyai/framework

--- a/src/relay/src/wippy.yaml
+++ b/src/relay/src/wippy.yaml
@@ -1,5 +1,6 @@
 organization: wippy
 module: relay
+type: library
 description: WebSocket relay and messaging infrastructure
 license: Apache-2.0
 repository: https://github.com/wippyai/framework

--- a/src/relay/test/wippy.yaml
+++ b/src/relay/test/wippy.yaml
@@ -1,3 +1,4 @@
 organization: wippy
 module: relay-test
+type: application
 description: Test stub for relay module

--- a/src/security/wippy.yaml
+++ b/src/security/wippy.yaml
@@ -1,5 +1,6 @@
 organization: wippy
 module: security
+type: library
 description: Security policies for access control
 license: Apache-2.0
 repository: https://github.com/wippyai/framework

--- a/src/terminal/wippy.yaml
+++ b/src/terminal/wippy.yaml
@@ -1,5 +1,6 @@
 organization: wippy
 module: terminal
+type: library
 description: Terminal UI components and utilities
 license: Apache-2.0
 repository: https://github.com/wippyai/framework

--- a/src/test/wippy.yaml
+++ b/src/test/wippy.yaml
@@ -1,5 +1,6 @@
 organization: wippy
 module: test
+type: library
 description: BDD-style testing framework
 license: Apache-2.0
 repository: https://github.com/wippyai/framework

--- a/src/usage/src/wippy.yaml
+++ b/src/usage/src/wippy.yaml
@@ -1,5 +1,6 @@
 organization: wippy
 module: usage
+type: library
 description: Token usage tracking for LLM applications
 license: Apache-2.0
 repository: https://github.com/wippyai/framework

--- a/src/usage/test/wippy.yaml
+++ b/src/usage/test/wippy.yaml
@@ -1,3 +1,4 @@
 organization: wippy
 module: usage-test
+type: application
 description: Test stub for usage module

--- a/src/views/test/wippy.yaml
+++ b/src/views/test/wippy.yaml
@@ -1,3 +1,4 @@
 organization: wippy
 module: views-test
+type: application
 description: Test stub for views module

--- a/src/views/wippy.yaml
+++ b/src/views/wippy.yaml
@@ -1,5 +1,6 @@
 organization: wippy
 module: views
+type: library
 description: Template views and page rendering
 license: Apache-2.0
 repository: https://github.com/wippyai/framework


### PR DESCRIPTION
Declares every installable Framework package as a library and every standalone test harness as an application. Adds a manifest convention gate to CI and publish-all so Hub publication can no longer silently fall back to the deprecated application default. Supersedes the incorrectly classified wippy/test 0.4.15 release with a correctly typed package after merge.