### PR TITLE
fix(relay): preserve sessions across hot upgrades

### DIFF
--- a/src/relay/src/_index.yaml
+++ b/src/relay/src/_index.yaml
@@ -187,6 +187,7 @@ entries:
     imports:
       consts: wippy.relay:consts
       test: wippy.test:test
+      user: wippy.relay:user
     modules:
       - time
       - security
@@ -209,5 +210,6 @@ entries:
     imports:
       central: wippy.relay:central
       test: wippy.test:test
-    modules: []
+    modules:
+      - time
     method: run

--- a/src/relay/src/central.lua
+++ b/src/relay/src/central.lua
@@ -34,10 +34,99 @@ type CentralState = {
     total_hubs: number,
 }
 
+type UserHubUpgradeInfo = {
+    hub_pid: string,
+    created_at: string?,
+    last_activity: string?,
+    client_count: number,
+    terminating: boolean?,
+    termination_started_at: string?,
+}
+
+type CentralUpgradeState = {
+    relay_upgrade: boolean,
+    user_hubs: {[string]: UserHubUpgradeInfo},
+    total_hubs: number,
+}
+
 local function table_length(t: any): number
     local count = 0
     for _ in pairs(t) do count = count + 1 end
     return count
+end
+
+local function encode_time(value: time.Time?): string?
+    if not value then return nil end
+    return value:format_rfc3339()
+end
+
+local function decode_time(value: any, field: string): time.Time?
+    if value == nil then return nil end
+    local parsed, parse_err = time.parse(time.RFC3339, tostring(value))
+    if not parsed then
+        error("invalid relay upgrade state " .. field .. ": " .. tostring(parse_err))
+    end
+    return parsed
+end
+
+local function snapshot_state(state: CentralState): CentralUpgradeState
+    local user_hubs: {[string]: UserHubUpgradeInfo} = {}
+    for user_id, hub in pairs(state.user_hubs) do
+        user_hubs[user_id] = {
+            hub_pid = hub.hub_pid,
+            created_at = encode_time(hub.created_at),
+            last_activity = encode_time(hub.last_activity),
+            client_count = hub.client_count,
+            terminating = hub.terminating,
+            termination_started_at = encode_time(hub.termination_started_at),
+        }
+    end
+    local snapshot: CentralUpgradeState = {
+        relay_upgrade = true,
+        user_hubs = user_hubs,
+        total_hubs = state.total_hubs,
+    }
+    return snapshot
+end
+
+local function encode_upgrade_state(snapshot: CentralUpgradeState): string
+    local encoded, encode_err = json.encode(snapshot)
+    if not encoded then
+        error("failed to encode relay central upgrade state: " .. tostring(encode_err))
+    end
+    return encoded
+end
+
+local function decode_upgrade_state(encoded: any): CentralUpgradeState
+    if type(encoded) ~= "string" then
+        error("invalid relay central upgrade state payload")
+    end
+    local snapshot, decode_err = json.decode(encoded)
+    if not snapshot then
+        error("failed to decode relay central upgrade state: " .. tostring(decode_err))
+    end
+    if type(snapshot) ~= "table" or snapshot.relay_upgrade ~= true then
+        error("invalid relay central upgrade state marker")
+    end
+    return snapshot :: CentralUpgradeState
+end
+
+local function restore_hubs(snapshot: CentralUpgradeState): {[string]: UserHubInfo}
+    local user_hubs: {[string]: UserHubInfo} = {}
+    for user_id, hub in pairs(snapshot.user_hubs or {}) do
+        if type(hub.hub_pid) ~= "string" or hub.hub_pid == "" then
+            error("invalid relay upgrade state hub_pid for " .. tostring(user_id))
+        end
+        user_hubs[user_id] = {
+            hub_pid = hub.hub_pid,
+            created_at = decode_time(hub.created_at, "created_at")!,
+            last_activity = decode_time(hub.last_activity, "last_activity")!,
+            client_count = tonumber(hub.client_count) or 0,
+            terminating = hub.terminating == true,
+            termination_started_at = decode_time(hub.termination_started_at, "termination_started_at"),
+        }
+    end
+    return user_hubs
 end
 
 local function identity_from_metadata(config: ValidatedConfig, user_id: string, metadata: any): (any?, any?, any?, string?)
@@ -202,7 +291,7 @@ local function check_inactive_hubs(state: CentralState)
     end
 end
 
-local function run(): any
+local function run(upgrade_state: any?): any
     local config = consts.get_config()
 
     logger:info("relay central hub starting", {
@@ -225,15 +314,31 @@ local function run(): any
 
     logger:info("plugin discovery complete", { plugin_count = table_length(plugins) })
 
+    local resumed = upgrade_state ~= nil
+    local user_hubs: {[string]: UserHubInfo} = {}
+    local total_hubs = 0
+    if resumed then
+        local snapshot = decode_upgrade_state(upgrade_state)
+        if type(snapshot.total_hubs) ~= "number" then
+            error("invalid relay upgrade state total_hubs")
+        end
+        user_hubs = restore_hubs(snapshot)
+        total_hubs = snapshot.total_hubs
+    end
     local state: CentralState = {
         config = config :: ValidatedConfig,
         plugins = plugins,
-        user_hubs = {},
-        total_hubs = 0
+        user_hubs = user_hubs,
+        total_hubs = total_hubs,
     }
 
-    process.registry.register(consts.CENTRAL_HUB_REGISTRY_NAME)
-    process.set_options({ trap_links = true, upgradable = false })
+    if not resumed then
+        local registered, register_err = process.registry.register(consts.CENTRAL_HUB_REGISTRY_NAME)
+        if not registered then
+            error("failed to register relay central hub: " .. tostring(register_err))
+        end
+    end
+    process.set_options({ trap_links = true, upgradable = true })
 
     local gc_ticker = time.ticker(config.gc_check_interval)
     local inbox = process.inbox()
@@ -274,6 +379,11 @@ local function run(): any
             if event.kind == process.event.CANCEL then
                 logger:info("received cancel signal")
                 break
+            elseif event.kind == process.event.OUTDATED then
+                local encoded_state = encode_upgrade_state(snapshot_state(state))
+                gc_ticker:stop()
+                logger:info("upgrading relay central hub", { active_hubs = state.total_hubs })
+                process.upgrade("", encoded_state)
             end
             handle_process_event(state, event)
 
@@ -299,4 +409,8 @@ return {
     _set_security_for_test = function(fake: any)
         security_mod = fake or security
     end,
+    _snapshot_state = snapshot_state,
+    _restore_hubs = restore_hubs,
+    _encode_upgrade_state = encode_upgrade_state,
+    _decode_upgrade_state = decode_upgrade_state,
 }

--- a/src/relay/src/central_test.lua
+++ b/src/relay/src/central_test.lua
@@ -1,5 +1,6 @@
 local test = require("test")
 local central = require("central")
+local time = require("time")
 
 local function fake_security(calls: any): any
     return {
@@ -65,6 +66,37 @@ local function define_tests()
             test.expect(type(meta)).to_equal("table")
             test.expect(calls.scope_id).to_equal("app.security:user")
             central._set_security_for_test(nil)
+        end)
+    end)
+
+    test.describe("relay central hot upgrade state", function()
+        test.it("serializes hub timestamps and restores the same child pids", function()
+            local now = time.now()
+            local snapshot = central._snapshot_state({
+                config = config("app.security:user"),
+                plugins = {},
+                user_hubs = {
+                    ["admin@wippy.local"] = {
+                        hub_pid = "app:hub:1",
+                        created_at = now,
+                        last_activity = now,
+                        client_count = 2,
+                    },
+                },
+                total_hubs = 1,
+            })
+
+            test.expect(snapshot.relay_upgrade).to_equal(true)
+            test.expect(type(snapshot.user_hubs["admin@wippy.local"].created_at)).to_equal("string")
+
+            local encoded = central._encode_upgrade_state(snapshot)
+            test.expect(type(encoded)).to_equal("string")
+            local decoded = central._decode_upgrade_state(encoded)
+            local restored = central._restore_hubs(decoded)
+            local hub = restored["admin@wippy.local"]
+            test.expect(hub.hub_pid).to_equal("app:hub:1")
+            test.expect(hub.client_count).to_equal(2)
+            test.expect(hub.created_at:format_rfc3339()).to_equal(now:format_rfc3339())
         end)
     end)
 end

--- a/src/relay/src/user.lua
+++ b/src/relay/src/user.lua
@@ -31,6 +31,19 @@ type UserState = {
     pg_groups: {[string]: string},
 }
 
+type UserUpgradeState = {
+    relay_user_upgrade: boolean,
+    user_id: string,
+    user_metadata: any,
+    plugins: {[string]: PluginConfig},
+    config: any,
+    central_hub_pid: string?,
+    active_plugins: {[string]: PluginState},
+    connected_clients: {[string]: boolean},
+    client_count: number,
+    pg_groups: {[string]: string},
+}
+
 local function get_plugin_info(state: UserState): any
     local count = 0
     for _ in pairs(state.plugins) do count = count + 1 end
@@ -126,6 +139,61 @@ local function release_pg(state: UserState)
         scope:release()
     end
     state.pg_scopes = {}
+end
+
+local function snapshot_state(state: UserState): UserUpgradeState
+    local groups = {}
+    for group, scope_id in pairs(state.pg_groups) do
+        groups[group] = scope_id
+    end
+    return {
+        relay_user_upgrade = true,
+        user_id = state.user_id,
+        user_metadata = state.user_metadata,
+        plugins = state.plugins,
+        config = state.config,
+        central_hub_pid = state.central_hub_pid,
+        active_plugins = state.active_plugins,
+        connected_clients = state.connected_clients,
+        client_count = state.client_count,
+        pg_groups = groups,
+    }
+end
+
+local function encode_upgrade_state(snapshot: UserUpgradeState): string
+    local encoded, encode_err = json.encode(snapshot)
+    if not encoded then
+        error("failed to encode relay user upgrade state: " .. tostring(encode_err))
+    end
+    return encoded
+end
+
+local function decode_upgrade_state(encoded: any): UserUpgradeState
+    if type(encoded) ~= "string" then
+        error("invalid relay user upgrade state payload")
+    end
+    local snapshot, decode_err = json.decode(encoded)
+    if not snapshot then
+        error("failed to decode relay user upgrade state: " .. tostring(decode_err))
+    end
+    if type(snapshot) ~= "table" or snapshot.relay_user_upgrade ~= true then
+        error("invalid relay user upgrade state marker")
+    end
+    return snapshot :: UserUpgradeState
+end
+
+local function restore_pg(state: UserState, groups: {[string]: string})
+    for group, scope_id in pairs(groups or {}) do
+        local scope, scope_err = pg_scope_for(state, scope_id)
+        if not scope then
+            error("failed to restore relay group " .. group .. ": " .. tostring(scope_err))
+        end
+        local joined, join_err = scope:join(group)
+        if not joined then
+            error("failed to restore relay group " .. group .. ": " .. tostring(join_err))
+        end
+        state.pg_groups[group] = scope_id
+    end
 end
 
 local function notify_central_hub_activity(state: UserState)
@@ -374,10 +442,25 @@ local function handle_process_event(state: UserState, event: any)
 end
 
 local function run(args: any): any
+    local resumed = type(args) == "string"
+    if resumed then
+        args = decode_upgrade_state(args)
+    end
     if not args or not args.user_id or not args.plugins or not args.config then
         error("Missing required arguments: user_id, plugins, config")
     end
 
+    local active_plugins: {[string]: PluginState} = {}
+    local connected_clients: {[string]: boolean} = {}
+    local client_count = 0
+    local upgrade_groups: {[string]: string} = {}
+    if resumed then
+        local resume_state = args :: UserUpgradeState
+        active_plugins = resume_state.active_plugins
+        connected_clients = resume_state.connected_clients
+        client_count = resume_state.client_count
+        upgrade_groups = resume_state.pg_groups
+    end
     local user_id = string(args.user_id)
     local central_hub_pid = args.central_hub_pid :: string?
 
@@ -388,24 +471,34 @@ local function run(args: any): any
         plugins = plugins,
         config = args.config,
         central_hub_pid = central_hub_pid,
-        active_plugins = {},
-        connected_clients = {},
-        client_count = 0,
+        active_plugins = active_plugins,
+        connected_clients = connected_clients,
+        client_count = client_count,
         pg_scopes = {},
         pg_groups = {}
     }
 
     local registry_name = consts.USER_HUB_REGISTRY_PREFIX .. state.user_id
-    local registered, register_err = process.registry.register(registry_name)
-    if not registered then
-        error("Failed to register user hub " .. registry_name .. ": " .. (register_err or "unknown error"))
+    if not resumed then
+        local registered, register_err = process.registry.register(registry_name)
+        if not registered then
+            error("Failed to register user hub " .. registry_name .. ": " .. (register_err or "unknown error"))
+        end
+        logger:info("user hub registered", { user_id = state.user_id, registry_name = registry_name })
     end
-    logger:info("user hub registered", { user_id = state.user_id, registry_name = registry_name })
-    process.set_options({ trap_links = true, upgradable = false })
+    process.set_options({ trap_links = true, upgradable = true })
 
-    for prefix, plugin_config in pairs(state.plugins) do
-        if plugin_config.auto_start then
-            spawn_plugin(state, prefix, plugin_config)
+    if resumed then
+        restore_pg(state, upgrade_groups)
+        logger:info("user hub upgraded", {
+            user_id = state.user_id,
+            client_count = state.client_count,
+        })
+    else
+        for prefix, plugin_config in pairs(state.plugins) do
+            if plugin_config.auto_start then
+                spawn_plugin(state, prefix, plugin_config)
+            end
         end
     end
 
@@ -448,6 +541,14 @@ local function run(args: any): any
             local event: any = result.value
             if event.kind == process.event.CANCEL then
                 break
+            elseif event.kind == process.event.OUTDATED then
+                local upgrade_state = encode_upgrade_state(snapshot_state(state))
+                release_pg(state)
+                logger:info("upgrading user hub", {
+                    user_id = state.user_id,
+                    client_count = state.client_count,
+                })
+                process.upgrade("", upgrade_state)
             else
                 handle_process_event(state, event)
             end
@@ -466,4 +567,9 @@ local function run(args: any): any
     return { status = "shutdown", user_id = state.user_id }
 end
 
-return { run = run }
+return {
+    run = run,
+    _snapshot_state = snapshot_state,
+    _encode_upgrade_state = encode_upgrade_state,
+    _decode_upgrade_state = decode_upgrade_state,
+}

--- a/src/relay/src/user_test.lua
+++ b/src/relay/src/user_test.lua
@@ -2,6 +2,7 @@ local test = require("test")
 local time = require("time")
 local consts = require("consts")
 local security = require("security")
+local user = require("user")
 
 local function define_tests()
     test.describe("relay user hub", function()
@@ -41,6 +42,34 @@ local function define_tests()
             test.expect(res.value.active_sessions).to_equal(0)
 
             process.cancel(hub_pid :: string, consts.CANCEL_TIMEOUT)
+        end)
+    end)
+
+    test.describe("relay user hot upgrade state", function()
+        test.it("preserves clients, child plugins, and group declarations without carrying handles", function()
+            local snapshot = user._snapshot_state({
+                user_id = "admin@wippy.local",
+                user_metadata = { email = "admin@wippy.local" },
+                plugins = { session_ = { prefix = "session_", process_id = "app:session", auto_start = true } },
+                config = { user_hub_host = "app:host" },
+                central_hub_pid = "app:central:1",
+                active_plugins = { session_ = { pid = "app:plugin:1", restart_count = 0, status = "running" } },
+                connected_clients = { ["app:client:1"] = true },
+                client_count = 1,
+                pg_scopes = { ["app:scope"] = { opaque = true } },
+                pg_groups = { ["workspace.1"] = "app:scope" },
+            })
+
+            test.expect(snapshot.relay_user_upgrade).to_equal(true)
+            test.expect(snapshot.active_plugins.session_.pid).to_equal("app:plugin:1")
+            test.expect(snapshot.connected_clients["app:client:1"]).to_equal(true)
+            test.expect(snapshot.pg_groups["workspace.1"]).to_equal("app:scope")
+
+            local encoded = user._encode_upgrade_state(snapshot)
+            test.expect(type(encoded)).to_equal("string")
+            local decoded = user._decode_upgrade_state(encoded)
+            test.expect(decoded.active_plugins.session_.pid).to_equal("app:plugin:1")
+            test.expect(decoded.connected_clients["app:client:1"]).to_equal(true)
         end)
     end)
 end


### PR DESCRIPTION
## Summary

- make Relay central and per-user hubs statefully upgradable
- preserve hub PIDs, child plugin PIDs, connected clients, counters, and process-group declarations
- transfer only serializable state and reopen process-group handles after upgrade
- handle Runtime `OUTDATED` through `process.upgrade` with no restart fallback

## Root cause

Relay services were marked `upgradable = false`. Package updates therefore could not use Runtime's in-place upgrade protocol, and external force termination broke active WebSocket/user-hub continuity.

## Verification

- Framework CI: Relay lint passed and all 19 Relay tests passed under v0.3.26a
- Framework CI module-manifest validation passed
- v0.3.26a live E2E:
  - central PID remained `0x00004`
  - user-hub PID remained `0x00055`
  - a WebSocket open before both upgrades stayed open
  - a second WebSocket connected after both upgrades
  - a Hub UI package install completed with the original WebSocket still open
  - full application restart restored registry history and accepted a fresh WebSocket
