### PR TITLE
fix(relay): drop per-broadcast info logs in broadcast_to_clients

### DIFF
--- a/src/relay/src/user.lua
+++ b/src/relay/src/user.lua
@@ -60,17 +60,7 @@ local function get_plugin_info(state: UserState): any
 end
 
 local function broadcast_to_clients(state: UserState, topic: string, message: any)
-    logger:info("broadcasting topic to clients", {
-        user_id = state.user_id,
-        topic = topic,
-        client_count = state.client_count
-    })
     for client_pid, _ in pairs(state.connected_clients) do
-        logger:info("broadcasting topic to client", {
-            user_id = state.user_id,
-            topic = topic,
-            client_pid = client_pid
-        })
         process.send(client_pid, topic, message)
     end
 end


### PR DESCRIPTION
broadcast_to_clients logs at info on every call and once per connected client. When log streaming is enabled (logmanager.stream_to_events) and a client subscribes to the live log topic over this same relay, each broadcast log re-enters the stream and is re-broadcast to that subscriber — which logs again. The result is a self-amplifying flood of "broadcasting topic to clients" whenever a log viewer is open (client_count grows, topic = the log topic).

This removes the two info logs in broadcast_to_clients. The fan-out (process.send) is unchanged; connect/disconnect/plugin/pg/error logging is untouched. Coordinated with the maintainer.