### PR TITLE
fix(facade): serve brand CSS variables to the shell before the host loads

### DIFF
--- a/src/facade/Makefile
+++ b/src/facade/Makefile
@@ -6,7 +6,7 @@
 # Run `make sync` after every Wippy Web Host version bump to pull fresh copies.
 
 # Web Host CDN base — update version when Wippy Web Host releases
-WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.52
+WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.53
 
 # Files to sync from CDN into public/@wippy-fe/
 CDN_FILES = loading.js

--- a/src/facade/README.md
+++ b/src/facade/README.md
@@ -78,7 +78,7 @@ These fields are NOT configurable via requirements — they are computed at runt
 
 | Requirement | Default | Description |
 |---|---|---|
-| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.52` | CDN base URL for the Web Host frontend bundle |
+| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.53` | CDN base URL for the Web Host frontend bundle |
 | `fe_entry_path` | `/iframe.html` | Iframe HTML entry point path (appended to `fe_facade_url`) |
 | `fe_mode` | `compat` | `compat` (default — loads `module.js`) or `managed` (loads `managed-layout.js` for declarative multi-panel apps). See [Modes](#modes) above |
 | `render_engine` | `iframe` | Global page render engine for packaged `view.page` micro-frontends: `iframe` (default — legacy srcdoc iframe) or `fragment` (Web Fragment / reframed realm reflected into a shadow root). `fragment` **requires** the `wippy/views` fragment gateway and a fragment-capable host bundle serving `/@wippy-fe/proxy-fragment.js`. Flows to the host as `hostConfig.renderEngine`; the child app is engine-agnostic (same package renders under either engine). |
@@ -390,9 +390,9 @@ Returns an empty body (200 OK) when no variables are configured. Response has `C
 
 ```json
 {
-  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.52",
+  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.53",
   "iframe_origin": "https://web-host.wippy.ai",
-  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.52/iframe.html?waitForCustomConfig",
+  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.53/iframe.html?waitForCustomConfig",
   "login_path": "/login.html",
   "login_redirect_param": null,
   "env": {

--- a/src/facade/_index.yaml
+++ b/src/facade/_index.yaml
@@ -39,7 +39,7 @@ entries:
     targets:
       - entry: wippy.facade:fe_facade_url
         path: .default
-    default: https://web-host.wippy.ai/webcomponents-1.0.52
+    default: https://web-host.wippy.ai/webcomponents-1.0.53
 
   - name: fe_entry_path
     kind: ns.requirement

--- a/src/facade/config_handler_test.lua
+++ b/src/facade/config_handler_test.lua
@@ -23,7 +23,7 @@ local REQ_NAMES: {string} = {
 
 local function setup_registry(overrides: {[string]: string}?)
     local defaults: {[string]: string} = {
-        fe_facade_url = "https://front.wippy.ai",
+        fe_facade_url = "https://web-host.wippy.ai/webcomponents-1.0.53",
         fe_entry_path = "/iframe.html",
         fe_mode = "compat",
         render_engine = "iframe",
@@ -188,7 +188,7 @@ local function define_tests()
             end)
 
             test.it("extracts iframe origin from facade URL", function()
-                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.52"
+                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.53"
                 local origin = facade_url:match("^(https?://[^/]+)")
 
                 test.eq(origin, "https://web-host.wippy.ai")
@@ -266,7 +266,7 @@ local function define_tests()
 
             test.it("returns all default requirement values", function()
                 local entry = registry.get(NS .. "fe_facade_url")
-                test.eq(entry.data.default, "https://web-host.wippy.ai/webcomponents-1.0.52")
+                test.eq(entry.data.default, "https://web-host.wippy.ai/webcomponents-1.0.53")
 
                 entry = registry.get(NS .. "fe_entry_path")
                 test.eq(entry.data.default, "/iframe.html")

--- a/src/facade/index.jet
+++ b/src/facade/index.jet
@@ -8,6 +8,12 @@
          window.wippyThemePersist. Render-blocking and first so there's no flash.
          In cookie mode the server already set the class on <html> above. -->
     <script src="/api/public/facade/theme-persist.js"></script>
+    <!-- Brand CSS variables, server-rendered from the css_variables requirement.
+         The loading overlay below paints before the Web Host bundle arrives, so
+         without this it renders on the loader's built-in fallback colours and
+         then shifts once the host injects the real theme. Same link the login
+         page uses. Must follow theme-persist, which sets the theme class. -->
+    <link rel="stylesheet" href="/api/public/facade/variables.css">
     <title>Wippy</title>
     <script src="/@wippy-fe/loading.js"></script>
     <style>

--- a/src/facade/test/config_dependency_test.lua
+++ b/src/facade/test/config_dependency_test.lua
@@ -9,7 +9,7 @@ local function run()
             local entry = registry.get(NS .. "fe_facade_url")
             test.not_nil(entry)
             test.not_nil(entry.data)
-            test.eq(entry.data.default, "https://web-host.wippy.ai/webcomponents-1.0.52")
+            test.eq(entry.data.default, "https://web-host.wippy.ai/webcomponents-1.0.53")
 
             entry = registry.get(NS .. "app_title")
             test.not_nil(entry)


### PR DESCRIPTION
## What

Links `/api/public/facade/variables.css` from the facade index `<head>`.

## Why

The index renders a `<wippy-loading>` overlay that paints **before** the Web Host
bundle arrives, but nothing supplied the brand variables at that point. The loader
painted on its built-in fallback colours and then shifted once the host injected the
real theme.

This is the endpoint the facade already ships and documents for exactly this case —
"non-Wippy-Host pages that need the same brand variables without embedding the full
Web Host" — and it is the same link the login page already uses. Both pre-host
surfaces now tone identically.

## Placement

After `theme-persist.js`, which must stay first so it sets the theme class before
paint, and before the loader script.

## Scope

The endpoint emits the `css_variables` requirement only. An app whose brand tokens
live in `custom_css` sees no change from this; it fixes the flash for apps that
configure `--p-*` variables.

Published as `wippy/facade@0.6.33`.