### PR TITLE
fix(llm): preserve classifier callback types

### DIFF
--- a/src/llm/src/bedrock/mapper.lua
+++ b/src/llm/src/bedrock/mapper.lua
@@ -29,7 +29,7 @@ local function approximate_token_count(text)
     return math.ceil(string.len(text) / 4)
 end
 
-function mapper.classify_error(bedrock_error)
+function mapper.classify_error(bedrock_error: any?): (string, string, table?)
     if not bedrock_error then
         return output.ERROR_TYPE.SERVER_ERROR, "Unknown Bedrock error", nil
     end
@@ -49,7 +49,7 @@ function mapper.classify_error(bedrock_error)
         if bedrock_error.metadata.request_id then details.request_id = bedrock_error.metadata.request_id end
     end
 
-    return kind, message, details
+    return kind, tostring(message), details
 end
 
 function mapper.map_tokens(converse_usage)

--- a/src/llm/src/claude/mapper.lua
+++ b/src/llm/src/claude/mapper.lua
@@ -102,7 +102,7 @@ local function collapse_cache_positions(system_positions, message_positions)
     return final_system, final_message
 end
 
-function mapper.classify_error(claude_error)
+function mapper.classify_error(claude_error: any?): (string, string, table?)
     if not claude_error then
         return output.ERROR_TYPE.SERVER_ERROR, "Unknown Claude error", nil
     end
@@ -128,7 +128,7 @@ function mapper.classify_error(claude_error)
         if claude_error.metadata.request_id then details.request_id = claude_error.metadata.request_id end
     end
 
-    return kind, message, details
+    return kind, tostring(message), details
 end
 
 function mapper.map_tokens(claude_usage)

--- a/src/llm/src/google/mapper.lua
+++ b/src/llm/src/google/mapper.lua
@@ -369,7 +369,7 @@ function mapper.map_success_response(google_response)
     return response
 end
 
-function mapper.classify_error(google_error)
+function mapper.classify_error(google_error: any?): (string, string, table?)
     if not google_error then
         return output.ERROR_TYPE.SERVER_ERROR, "Unknown Google error", nil
     end
@@ -386,7 +386,7 @@ function mapper.classify_error(google_error)
         if google_error.metadata.request_id then details.request_id = google_error.metadata.request_id end
     end
 
-    return kind, message, details
+    return kind, tostring(message), details
 end
 
 -- Standardize content to a simple string (for instructions)

--- a/src/llm/src/openai/mapper.lua
+++ b/src/llm/src/openai/mapper.lua
@@ -536,7 +536,7 @@ end
 
 -- Pure classifier: turn an HTTP / transport error into (kind, message, details).
 -- Consumed by output.errors.<op>(...):classifier(openai_mapper.classify_error):from(err):build()
-function openai_mapper.classify_error(api_error)
+function openai_mapper.classify_error(api_error: any?): (string, string, table?)
     if not api_error then
         return output.ERROR_TYPE.SERVER_ERROR, "Unknown OpenAI error", nil
     end
@@ -555,7 +555,7 @@ function openai_mapper.classify_error(api_error)
         if api_error.metadata.organization then details.organization = api_error.metadata.organization end
     end
 
-    return kind, message, details
+    return kind, tostring(message), details
 end
 
 return openai_mapper

--- a/src/llm/src/openai_compat/mapper.lua
+++ b/src/llm/src/openai_compat/mapper.lua
@@ -554,7 +554,7 @@ function openai_mapper.map_success_response(openai_response, context)
 end
 
 -- Pure classifier: turn an HTTP / transport error into (kind, message, details).
-function openai_mapper.classify_error(openai_error)
+function openai_mapper.classify_error(openai_error: any?): (string, string, table?)
     if not openai_error then
         return output.ERROR_TYPE.SERVER_ERROR, "Unknown OpenAI-compatible error", nil
     end
@@ -575,7 +575,7 @@ function openai_mapper.classify_error(openai_error)
     if openai_error.nested_error then details.nested_error = openai_error.nested_error end
     if openai_error.provider_name then details.upstream_provider = openai_error.provider_name end
 
-    return kind, message, details
+    return kind, tostring(message), details
 end
 
 -- Standardize content to a simple string (for assistant and tool messages)


### PR DESCRIPTION
## Summary
- declare the shared ClassifyError-compatible signature on every built-in provider mapper
- normalize provider error messages to the string already required by the callback contract
- preserve exported callback types when wippy/llm is packaged and consumed by strict applications

## Root cause
Source-mode analysis inferred classify_error while the package was compiled as one graph. Across the published library boundary, the unannotated export degraded to any. Strict consumers then rejected it at ErrorBuilder:classifier, which requires ClassifyError.

## Compatibility
No provider IDs, entry kinds, bindings, schemas, request payloads, or driver behavior change. The annotation is applied consistently to OpenAI, OpenAI-compatible, Claude, Google, and Bedrock.

## Verification
- strict lint: 97 entries, 0 issues
- full LLM suite: 1,198/1,198 passing with live integration tests disabled
- module manifest conventions: 14 libraries and 10 test applications passing
- dry-run package: wippy/llm 0.4.37 built successfully
- packaged dependency consumed by Bee under strict mode with its four temporary OpenAI overrides removed: 136 entries, 0 issues