### PR TITLE
fix(llm): type classifier handler seams

### DIFF
--- a/src/llm/src/bedrock/embed.lua
+++ b/src/llm/src/bedrock/embed.lua
@@ -4,6 +4,8 @@ local output = require("output")
 local embed_titan = require("embed_titan")
 local embed_cohere = require("embed_cohere")
 
+type ClassifyError = (http_err: any?) -> (string, string, table?)
+
 local embed_handler = {
     _client = bedrock_client,
     _titan = embed_titan,
@@ -72,7 +74,7 @@ local function embed_with_cohere(client, model_id, input, options)
 end
 
 function embed_handler.handler(contract_args)
-    local err_b = output.errors.embed(contract_args):classifier(mapper.classify_error)
+    local err_b = output.errors.embed(contract_args):classifier(mapper.classify_error :: ClassifyError)
 
     if not contract_args.model then
         return nil, err_b:kind(output.ERROR_TYPE.INVALID_REQUEST):message("Model is required"):build()

--- a/src/llm/src/bedrock/generate.lua
+++ b/src/llm/src/bedrock/generate.lua
@@ -2,6 +2,8 @@ local bedrock_client = require("bedrock_client")
 local mapper = require("mapper")
 local output = require("output")
 
+type ClassifyError = (http_err: any?) -> (string, string, table?)
+
 local generate_handler = {
     _client = bedrock_client,
     _mapper = mapper,
@@ -76,7 +78,8 @@ local function handle_streaming(stream_response, context, stream_config, err)
 end
 
 function generate_handler.handler(contract_args)
-    local err = output.errors.generate(contract_args):classifier(generate_handler._mapper.classify_error)
+    local err = output.errors.generate(contract_args)
+        :classifier(generate_handler._mapper.classify_error :: ClassifyError)
 
     if not contract_args.model then
         return nil, err:kind(output.ERROR_TYPE.INVALID_REQUEST):message("Model is required"):build()

--- a/src/llm/src/bedrock/structured_output.lua
+++ b/src/llm/src/bedrock/structured_output.lua
@@ -3,6 +3,8 @@ local mapper = require("mapper")
 local output = require("output")
 local json = require("json")
 
+type ClassifyError = (http_err: any?) -> (string, string, table?)
+
 local structured_output_handler = {
     _client = bedrock_client,
     _mapper = mapper,
@@ -58,7 +60,8 @@ local function validate_schema(schema)
 end
 
 function structured_output_handler.handler(contract_args)
-    local err = output.errors.structured_output(contract_args):classifier(structured_output_handler._mapper.classify_error)
+    local err = output.errors.structured_output(contract_args)
+        :classifier(structured_output_handler._mapper.classify_error :: ClassifyError)
 
     if not contract_args.model then
         return nil, err:kind(output.ERROR_TYPE.INVALID_REQUEST):message("Model is required"):build()

--- a/src/llm/src/claude/generate.lua
+++ b/src/llm/src/claude/generate.lua
@@ -3,6 +3,8 @@ local mapper = require("mapper")
 local output = require("output")
 local json = require("json")
 
+type ClassifyError = (http_err: any?) -> (string, string, table?)
+
 local generate_handler = {
     _client = claude_client,
     _mapper = mapper,
@@ -77,7 +79,8 @@ local function handle_streaming(stream_response, context, stream_config, err)
 end
 
 function generate_handler.handler(contract_args)
-    local err = output.errors.generate(contract_args):classifier(generate_handler._mapper.classify_error)
+    local err = output.errors.generate(contract_args)
+        :classifier(generate_handler._mapper.classify_error :: ClassifyError)
 
     if not contract_args.model then
         return nil, err:kind(output.ERROR_TYPE.INVALID_REQUEST):message("Model is required"):build()

--- a/src/llm/src/claude/structured_output.lua
+++ b/src/llm/src/claude/structured_output.lua
@@ -4,6 +4,8 @@ local output = require("output")
 local json = require("json")
 local hash = require("hash")
 
+type ClassifyError = (http_err: any?) -> (string, string, table?)
+
 local structured_output_handler = {
     _client = claude_client,
     _mapper = mapper,
@@ -59,7 +61,8 @@ local function validate_schema(schema)
 end
 
 function structured_output_handler.handler(contract_args)
-    local err = output.errors.structured_output(contract_args):classifier(structured_output_handler._mapper.classify_error)
+    local err = output.errors.structured_output(contract_args)
+        :classifier(structured_output_handler._mapper.classify_error :: ClassifyError)
 
     if not contract_args.model then
         return nil, err:kind(output.ERROR_TYPE.INVALID_REQUEST):message("Model is required"):build()

--- a/src/llm/src/google/generate.lua
+++ b/src/llm/src/google/generate.lua
@@ -4,6 +4,8 @@ local output = require("output")
 local config = require("google_config")
 local ctx = require("ctx")
 
+type ClassifyError = (http_err: any?) -> (string, string, table?)
+
 local generate = {
     _ctx = ctx,
     _contract = contract,
@@ -12,7 +14,8 @@ local generate = {
 }
 
 function generate.handler(contract_args)
-    local err = output.errors.generate(contract_args):classifier(generate._mapper.classify_error)
+    local err = output.errors.generate(contract_args)
+        :classifier(generate._mapper.classify_error :: ClassifyError)
 
     if not contract_args.model then
         return nil, err:kind(output.ERROR_TYPE.INVALID_REQUEST):message("Model is required"):build()

--- a/src/llm/src/google/structured_output.lua
+++ b/src/llm/src/google/structured_output.lua
@@ -6,6 +6,8 @@ local hash = require("hash")
 local config = require("google_config")
 local ctx = require("ctx")
 
+type ClassifyError = (http_err: any?) -> (string, string, table?)
+
 local structured_output = {
     _ctx = ctx,
     _contract = contract,
@@ -36,7 +38,7 @@ end
 
 function structured_output.handler(contract_args)
     local err = output.errors.structured_output(contract_args)
-        :classifier(structured_output._mapper.classify_error)
+        :classifier(structured_output._mapper.classify_error :: ClassifyError)
 
     if not contract_args.model then
         return nil, err:kind(output.ERROR_TYPE.INVALID_REQUEST):message("Model is required"):build()

--- a/src/llm/src/openai/embed.lua
+++ b/src/llm/src/openai/embed.lua
@@ -2,6 +2,8 @@ local openai_client = require("openai_client")
 local openai_mapper = require("openai_mapper")
 local output = require("output")
 
+type ClassifyError = (http_err: any?) -> (string, string, table?)
+
 local embeddings_handler = {
     _client = openai_client,
     _mapper = openai_mapper
@@ -9,7 +11,7 @@ local embeddings_handler = {
 
 function embeddings_handler.handler(contract_args)
     local err = output.errors.embed(contract_args)
-        :classifier(embeddings_handler._mapper.classify_error)
+        :classifier(embeddings_handler._mapper.classify_error :: ClassifyError)
 
     if not contract_args.model then
         return nil, err:kind(output.ERROR_TYPE.INVALID_REQUEST):message("Model is required"):build()

--- a/src/llm/src/openai/generate.lua
+++ b/src/llm/src/openai/generate.lua
@@ -2,6 +2,8 @@ local openai_client = require("openai_client")
 local openai_mapper = require("openai_mapper")
 local output = require("output")
 
+type ClassifyError = (http_err: any?) -> (string, string, table?)
+
 local generate_handler = {
     _client = openai_client,
     _mapper = openai_mapper,
@@ -101,7 +103,8 @@ local function handle_streaming(stream_response, context, stream_config, err)
 end
 
 function generate_handler.handler(contract_args)
-    local err = output.errors.generate(contract_args):classifier(generate_handler._mapper.classify_error)
+    local err = output.errors.generate(contract_args)
+        :classifier(generate_handler._mapper.classify_error :: ClassifyError)
 
     if not contract_args.model then
         return nil, err:kind(output.ERROR_TYPE.INVALID_REQUEST):message("Model is required"):build()

--- a/src/llm/src/openai/structured_output.lua
+++ b/src/llm/src/openai/structured_output.lua
@@ -4,6 +4,8 @@ local output = require("output")
 local json = require("json")
 local hash = require("hash")
 
+type ClassifyError = (http_err: any?) -> (string, string, table?)
+
 local structured_output_handler = {
     _client = openai_client,
     _mapper = openai_mapper
@@ -67,7 +69,7 @@ end
 
 function structured_output_handler.handler(contract_args)
     local err = output.errors.structured_output(contract_args)
-        :classifier(structured_output_handler._mapper.classify_error)
+        :classifier(structured_output_handler._mapper.classify_error :: ClassifyError)
 
     if not contract_args.model then
         return nil, err:kind(output.ERROR_TYPE.INVALID_REQUEST):message("Model is required"):build()

--- a/src/llm/src/openai_compat/embed.lua
+++ b/src/llm/src/openai_compat/embed.lua
@@ -2,6 +2,8 @@ local openai_client = require("openai_client")
 local openai_mapper = require("openai_mapper")
 local output = require("output")
 
+type ClassifyError = (http_err: any?) -> (string, string, table?)
+
 local embeddings_handler = {
     _client = openai_client,
     _mapper = openai_mapper
@@ -9,7 +11,7 @@ local embeddings_handler = {
 
 function embeddings_handler.handler(contract_args)
     local err = output.errors.embed(contract_args)
-        :classifier(embeddings_handler._mapper.classify_error)
+        :classifier(embeddings_handler._mapper.classify_error :: ClassifyError)
 
     if not contract_args.model then
         return nil, err:kind(output.ERROR_TYPE.INVALID_REQUEST):message("Model is required"):build()

--- a/src/llm/src/openai_compat/generate.lua
+++ b/src/llm/src/openai_compat/generate.lua
@@ -2,6 +2,8 @@ local openai_client = require("openai_client")
 local openai_mapper = require("openai_mapper")
 local output = require("output")
 
+type ClassifyError = (http_err: any?) -> (string, string, table?)
+
 local generate_handler = {
     _client = openai_client,
     _mapper = openai_mapper,
@@ -100,7 +102,7 @@ end
 
 function generate_handler.handler(contract_args)
     local err = output.errors.generate(contract_args)
-        :classifier(generate_handler._mapper.classify_error)
+        :classifier(generate_handler._mapper.classify_error :: ClassifyError)
 
     if not contract_args.model then
         return nil, err:kind(output.ERROR_TYPE.INVALID_REQUEST):message("Model is required"):build()

--- a/src/llm/src/openai_compat/structured_output.lua
+++ b/src/llm/src/openai_compat/structured_output.lua
@@ -4,6 +4,8 @@ local output = require("output")
 local json = require("json")
 local hash = require("hash")
 
+type ClassifyError = (http_err: any?) -> (string, string, table?)
+
 local structured_output_handler = {
     _client = openai_client,
     _mapper = openai_mapper
@@ -68,7 +70,7 @@ end
 
 function structured_output_handler.handler(contract_args)
     local err = output.errors.structured_output(contract_args)
-        :classifier(structured_output_handler._mapper.classify_error)
+        :classifier(structured_output_handler._mapper.classify_error :: ClassifyError)
 
     if not contract_args.model then
         return nil, err:kind(output.ERROR_TYPE.INVALID_REQUEST):message("Model is required"):build()


### PR DESCRIPTION
## Summary
- assert the ClassifyError contract at every built-in handler mapper seam
- preserve mutable mapper injection used by unit tests and custom provider implementations
- cover OpenAI, OpenAI-compatible, Claude, Google, and Bedrock consistently

## Why this follows #102
PR #102 typed the mapper exports, but a real strict Bee boot against the published 0.4.37 artifact found a second boundary: handler tables intentionally retain mutable _mapper fields for dependency injection, and runtime pool compilation sees callbacks read through those seams as any.

The correction keeps ErrorBuilder:classifier strict. It annotates the dynamic seam instead of weakening the central contract or changing entry kinds.

## Compatibility
This is compile-time-only. Provider IDs, entry kinds, contracts, bindings, mapper injection, request/response behavior, and test mocks are unchanged.

## Verification
- strict lint: 97 entries, 0 issues
- full suite: 1,198/1,198 passing; live provider integrations disabled
- module manifests: 14 libraries and 10 test applications passing
- exact wippy publish --dry-run 0.4.38 artifact loaded under strict runtime
- all 101 published entries compiled; every built-in driver registered; runtime reached ready

Supersedes 0.4.37 for strict runtime consumers.