### PR TITLE
Fix LLM refresher shutdown handling

### DIFF
--- a/src/llm/src/bedrock/credential_refresher.lua
+++ b/src/llm/src/bedrock/credential_refresher.lua
@@ -57,13 +57,19 @@ local function has_metadata_endpoint()
 end
 
 local function run(args)
+    local events = process.events()
+
     if not has_metadata_endpoint() then
         print("No metadata credentials endpoint, AWS credential refresher will not start.")
-        local events = process.events()
         while true do
             local result = channel.select({
                 events:case_receive()
             })
+
+            if not result.ok then
+                break
+            end
+
             if result.value and result.value.kind == process.event.CANCEL then
                 break
             end
@@ -75,8 +81,6 @@ local function run(args)
 
     local ticker = time.ticker(REFRESH_INTERVAL)
     local ticker_channel = ticker:channel()
-    local events = process.events()
-
     refresh_credentials()
 
     while running do
@@ -84,6 +88,10 @@ local function run(args)
             ticker_channel:case_receive(),
             events:case_receive()
         })
+
+        if not result.ok then
+            break
+        end
 
         if result.channel == ticker_channel then
             refresh_credentials()

--- a/src/llm/src/google/oauth2/token_refresher.lua
+++ b/src/llm/src/google/oauth2/token_refresher.lua
@@ -44,13 +44,19 @@ end
 
 -- Process to refresh tokens periodically
 local function run(args)
+    local events = process.events()
+
     if not config.has_credentials() then
         print("Google credentials are missing, Google OAuth2 token refresher will not start.")
-        local events = process.events()
         while true do
             local result = channel.select({
                 events:case_receive()
             })
+
+            if not result.ok then
+                break
+            end
+
             if result.value and result.value.kind == process.event.CANCEL then
                 break
             end
@@ -63,8 +69,6 @@ local function run(args)
     local ticker = time.ticker(REFRESH_INTERVAL)
     local ticker_channel = ticker:channel()
 
-    local events = process.events()
-
     refresh_token()
 
     while running do
@@ -72,6 +76,10 @@ local function run(args)
             ticker_channel:case_receive(),
             events:case_receive()
         })
+
+        if not result.ok then
+            break
+        end
 
         if result.channel == ticker_channel then
             refresh_token()


### PR DESCRIPTION
## Summary
- subscribe to process lifecycle events before provider discovery or refresh work
- terminate both idle and timed refresher loops when their event channel closes
- preserve existing Google and Bedrock credential refresh behavior

## Verification
- strict LLM lint: 97 entries, no issues
- LLM suite: 1,198 tests passed
- generic process-host lifecycle run: clean shutdown in 3.36s total with no service stop timeout
- module manifests: 14 libraries and 10 test applications passed

The generic-host lifecycle run binds the package's documented process_host requirement to an app process host; no provider credentials or live OpenAI calls were used.