### PR TITLE
feat(test): run the CLI test runner under a declared root security scope

### DIFF
--- a/src/test/_index.yaml
+++ b/src/test/_index.yaml
@@ -61,6 +61,16 @@ entries:
       - json
       - ctx
 
+  # wippy.test:runner_policy
+  - name: runner_policy
+    kind: security.policy
+    meta:
+      comment: Root scope for the CLI test runner. The runner discovers and executes arbitrary registry entries, so it requires unrestricted access; the CLI launcher installing it is the trust anchor.
+    policy:
+      resources: '*'
+      actions: '*'
+      effect: allow
+
   # wippy.test:runner
   - name: runner
     kind: process.lua
@@ -70,6 +80,11 @@ entries:
         name: test
         short: Run tests
         use_case: test
+        security:
+          actor:
+            id: wippy.test:runner
+          policies:
+            - wippy.test:runner_policy
     source: file://runner.lua
     method: main
     modules:


### PR DESCRIPTION
Companion to wippyai/runtime#558.

The test runner discovers and executes arbitrary registry entries, so it needs an unrestricted scope; the CLI launcher installing it is the trust anchor (the operator started `wippy run test` on their own deployment).

- `wippy.test:runner_policy` — allow-all security.policy owned by the module.
- `wippy.test:runner` — declares `meta.command.security` (actor `wippy.test:runner`, policy `runner_policy`), which the patched CLI resolves and installs at launch.

Under strict security mode (default since runtime v0.3.27a) the actor-less runner had every registry read denied and reported **No tests found** on every module harness. With runtime#558 + this change, the kickside-module template harness discovers and passes its full suite with strict mode on (verified E2E; stock CLI on the same tree still fails, proving the launcher change is the enabling piece).

On CLIs without runtime#558 the extra meta and policy entry are inert; behavior is unchanged. Needs a wippy/test republish once merged.