### PR TITLE
fix(agent, llm): improve message handling to support image, document in extract_recent_actions

### DIFF
--- a/src/agent/src/agent.lua
+++ b/src/agent/src/agent.lua
@@ -177,6 +177,23 @@ local function extract_memory_ids_from_messages(messages: any, scan_limit: any):
     return memory_ids
 end
 
+local function part_text(message: any): string
+    local part = message and message.content and message.content[1]
+    if not part then
+        return "nil"
+    end
+    if type(part.text) == "string" then
+        return part.text
+    end
+    if part.type == "image" then
+        return "[image]"
+    end
+    if part.type == "document" then
+        return "[document]"
+    end
+    return "[non-text content]"
+end
+
 local function extract_recent_actions(messages: any, max_actions: any, message_types: any): any
     if not messages or #messages == 0 then
         return {}
@@ -199,16 +216,14 @@ local function extract_recent_actions(messages: any, max_actions: any, message_t
         local message = messages[i]
         if message.role and type_lookup[message.role] then
             if message.role == prompt.ROLE.USER and message.content and message.content[1] then
-                table.insert(actions, 1, "user: " .. message.content[1].text)
+                table.insert(actions, 1, "user: " .. part_text(message))
             elseif message.role == prompt.ROLE.ASSISTANT and message.content and message.content[1] then
-                table.insert(actions, 1, "assistant: " .. message.content[1].text)
+                table.insert(actions, 1, "assistant: " .. part_text(message))
             elseif message.role == prompt.ROLE.FUNCTION_RESULT and message.name then
-                local content = message.content and message.content[1] and message.content[1].text or "nil"
-                table.insert(actions, 1, "tool: " .. message.name .. " -> " .. content)
+                table.insert(actions, 1, "tool: " .. message.name .. " -> " .. part_text(message))
             elseif message.role == prompt.ROLE.DEVELOPER and message.content and message.content[1] then
                 if not (message.metadata and message.metadata.memory_ids) then
-                    local content = message.content[1].text
-                    table.insert(actions, 1, "system: " .. content)
+                    table.insert(actions, 1, "system: " .. part_text(message))
                 end
             end
         end

--- a/src/agent/src/agent_memory_test.lua
+++ b/src/agent/src/agent_memory_test.lua
@@ -348,6 +348,41 @@ local function define_tests()
                 end
                 test.is_true(found_normal)
             end)
+
+            it("should handle image-only content parts from the _images channel", function()
+                local memory_contract = create_mock_memory_contract()
+                mock_contract._current_instance = memory_contract
+
+                local spec = {
+                    id = "test-agent",
+                    name = "Test Agent",
+                    prompt = "Test agent",
+                    tools = {},
+                    memory_contract = {
+                        implementation_id = "test:memory"
+                    }
+                }
+
+                local test_agent = agent.new(spec)
+                local prompt_builder = mock_prompt.new()
+
+                prompt_builder:add_user("What is in this picture?")
+                prompt_builder:add_function_result("look_at_image", '{"success":true}', "call_1")
+
+                -- Exactly what get_messages() appends for a stripped `_images` payload.
+                local messages = prompt_builder:get_messages()
+                table.insert(messages, create_message("user", {
+                    { type = "image", source = { type = "url", url = "https://example.com/a.png" } }
+                }))
+
+                test_agent:step(prompt_builder)
+
+                local call_log = memory_contract:get_call_log()
+                test.eq(#call_log, 1)
+
+                local recent_actions = (call_log[1] :: any).recent_actions
+                test.eq(recent_actions[#recent_actions], "user: [image]")
+            end)
         end)
 
         describe("Memory ID Extraction and Deduplication", function()

--- a/src/llm/src/claude/mapper.lua
+++ b/src/llm/src/claude/mapper.lua
@@ -339,13 +339,21 @@ function mapper.map_messages(contract_messages)
                 else
                     -- Try to merge into previous message (existing logic)
                     local last_msg = claude_messages[#claude_messages]
+                    local merged = false
                     for j = #last_msg.content, 1, -1 do
                         local part = last_msg.content[j] :: any
                         if part.type == "text" then
                             part.text = part.text ..
                                 "\n<developer-instruction>" .. dev_text .. "</developer-instruction>"
+                            merged = true
                             break
                         end
+                    end
+                    if not merged then
+                        table.insert(last_msg.content, {
+                            type = "text",
+                            text = "<developer-instruction>" .. dev_text .. "</developer-instruction>"
+                        })
                     end
                 end
             end

--- a/src/llm/src/claude/mapper_test.lua
+++ b/src/llm/src/claude/mapper_test.lua
@@ -172,6 +172,34 @@ local function define_tests()
                 test.contains(tostring(first_content.text), "<developer-instruction>Be concise</developer-instruction>")
             end)
 
+            it("should append developer messages to an image-only previous message", function()
+                local contract_messages = {
+                    { role = prompt.ROLE.USER, content = { { type = "text", text = "Look at this" } } },
+                    {
+                        role = prompt.ROLE.USER,
+                        content = {
+                            { type = "image", source = { type = "url", url = "https://example.com/a.png" } }
+                        }
+                    },
+                    { role = prompt.ROLE.DEVELOPER, content = "Be concise" }
+                }
+
+                local result = mapper.map_messages(contract_messages)
+                local last_msg = result.messages[#result.messages] :: any
+
+                local found = false
+                for _, part in ipairs(last_msg.content) do
+                    if (part :: any).type == "text" and
+                       tostring((part :: any).text):find("<developer-instruction>Be concise</developer-instruction>", 1, true) then
+                        found = true
+                    end
+                end
+                test.is_true(found, "developer instruction must survive an image-only previous message")
+
+                -- The image itself must still be there.
+                test.eq((last_msg.content[1] :: any).type, "image")
+            end)
+
             it("should convert function calls to assistant tool_use format", function()
                 local contract_messages = {
                     {


### PR DESCRIPTION
## What was changed

  - `agent`: `part_text` helper renders a message's content part — its `.text` when present, `[image]` / `[document]` for media, `[non-text content]` otherwise. Used in all four branches of `extract_recent_actions`
  - `llm`: the mapper tracks whether the merge succeeded and appends a text part  when no text part exists, instead of dropping the instruction

## Why?

Any tool returning an image to the calling agent through the `_images` tool-result channel killed the agent process. `wippy.llm:prompt.get_messages()` strips `_images` out of the function result and re-injects the pictures as `{role = USER, content = collected_images}` — a message whose parts are all images, with no `.text` anywhere. Two separate defects fire on that message.

1. `extract_recent_actions` crashes the agent process `"user: " .. message.content[1].text` concatenated nil, killing the process mid-turn. The dataflow node was left `running` and the failure surfaced as `COMPLETE_WORKFLOW must be the first command in a command batch` — a downstream symptom, not the cause. Nothing reached the logger because the process was gone. Only agents with a `memory_contract` were affected: `extract_recent_actions` is reached only via `perform_memory_recall`, which returns early without one. The `FUNCTION_RESULT` branch already guarded this with `or "nil"`; `USER`, `ASSISTANT` and `DEVELOPER` did not

2. The Claude mapper silently drops the developer instruction `agent:step` appends the memory recall as a `DEVELOPER` message last — directly after that image-only message. `should_create_new_message` only tests for `tool_result`, so an image-only message takes the merge path; the merge loop scans for a text part, finds none, and falls through. The recalled memory was discarded with no error, on every turn following an attached image               
