### PR TITLE
chore(facade): point the CDN ref at web host 1.0.57

### DIFF
--- a/src/facade/Makefile
+++ b/src/facade/Makefile
@@ -6,7 +6,7 @@
 # Run `make sync` after every Wippy Web Host version bump to pull fresh copies.
 
 # Web Host CDN base — update version when Wippy Web Host releases
-WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.56
+WEB_HOST_CDN = https://web-host.wippy.ai/webcomponents-1.0.57
 
 # Files to sync from CDN into public/@wippy-fe/
 CDN_FILES = loading.js

--- a/src/facade/README.md
+++ b/src/facade/README.md
@@ -78,7 +78,7 @@ These fields are NOT configurable via requirements — they are computed at runt
 
 | Requirement | Default | Description |
 |---|---|---|
-| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.56` | CDN base URL for the Web Host frontend bundle |
+| `fe_facade_url` | `https://web-host.wippy.ai/webcomponents-1.0.57` | CDN base URL for the Web Host frontend bundle |
 | `fe_entry_path` | `/iframe.html` | Iframe HTML entry point path (appended to `fe_facade_url`) |
 | `fe_mode` | `compat` | `compat` (default — loads `module.js`) or `managed` (loads `managed-layout.js` for declarative multi-panel apps). See [Modes](#modes) above |
 | `render_engine` | `iframe` | Global page render engine for packaged `view.page` micro-frontends: `iframe` (default — legacy srcdoc iframe) or `fragment` (Web Fragment / reframed realm reflected into a shadow root). `fragment` **requires** the `wippy/views` fragment gateway and a fragment-capable host bundle serving `/@wippy-fe/proxy-fragment.js`. Flows to the host as `hostConfig.renderEngine`; the child app is engine-agnostic (same package renders under either engine). |
@@ -390,9 +390,9 @@ Returns an empty body (200 OK) when no variables are configured. Response has `C
 
 ```json
 {
-  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.56",
+  "facade_url": "https://web-host.wippy.ai/webcomponents-1.0.57",
   "iframe_origin": "https://web-host.wippy.ai",
-  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.56/iframe.html?waitForCustomConfig",
+  "iframe_url": "https://web-host.wippy.ai/webcomponents-1.0.57/iframe.html?waitForCustomConfig",
   "login_path": "/login.html",
   "login_redirect_param": null,
   "env": {

--- a/src/facade/_index.yaml
+++ b/src/facade/_index.yaml
@@ -39,7 +39,7 @@ entries:
     targets:
       - entry: wippy.facade:fe_facade_url
         path: .default
-    default: https://web-host.wippy.ai/webcomponents-1.0.56
+    default: https://web-host.wippy.ai/webcomponents-1.0.57
 
   - name: fe_entry_path
     kind: ns.requirement

--- a/src/facade/config_handler_test.lua
+++ b/src/facade/config_handler_test.lua
@@ -23,7 +23,7 @@ local REQ_NAMES: {string} = {
 
 local function setup_registry(overrides: {[string]: string}?)
     local defaults: {[string]: string} = {
-        fe_facade_url = "https://web-host.wippy.ai/webcomponents-1.0.56",
+        fe_facade_url = "https://web-host.wippy.ai/webcomponents-1.0.57",
         fe_entry_path = "/iframe.html",
         fe_mode = "compat",
         render_engine = "iframe",
@@ -188,7 +188,7 @@ local function define_tests()
             end)
 
             test.it("extracts iframe origin from facade URL", function()
-                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.56"
+                local facade_url = "https://web-host.wippy.ai/webcomponents-1.0.57"
                 local origin = facade_url:match("^(https?://[^/]+)")
 
                 test.eq(origin, "https://web-host.wippy.ai")
@@ -266,7 +266,7 @@ local function define_tests()
 
             test.it("returns all default requirement values", function()
                 local entry = registry.get(NS .. "fe_facade_url")
-                test.eq(entry.data.default, "https://web-host.wippy.ai/webcomponents-1.0.56")
+                test.eq(entry.data.default, "https://web-host.wippy.ai/webcomponents-1.0.57")
 
                 entry = registry.get(NS .. "fe_entry_path")
                 test.eq(entry.data.default, "/iframe.html")

--- a/src/facade/test/config_dependency_test.lua
+++ b/src/facade/test/config_dependency_test.lua
@@ -9,7 +9,7 @@ local function run()
             local entry = registry.get(NS .. "fe_facade_url")
             test.not_nil(entry)
             test.not_nil(entry.data)
-            test.eq(entry.data.default, "https://web-host.wippy.ai/webcomponents-1.0.56")
+            test.eq(entry.data.default, "https://web-host.wippy.ai/webcomponents-1.0.57")
 
             entry = registry.get(NS .. "app_title")
             test.not_nil(entry)


### PR DESCRIPTION
Moves the facade's Web Host reference from `webcomponents-1.0.56` to `-1.0.57`.
