### PR TITLE
fix(llm): developer message after assistant turn opens a user message

### DIFF
--- a/src/llm/src/claude/integration_test.lua
+++ b/src/llm/src/claude/integration_test.lua
@@ -164,6 +164,45 @@ local function define_tests()
                 test.contains(response.result.content, "Absolutely")
             end)
 
+            it("should recover a truncated turn on a model that rejects assistant prefill", function()
+                if not RUN_INTEGRATION_TESTS then
+                    print("Skipping integration test - not enabled")
+                    return
+                end
+
+                -- The truncation-recovery shape the agent loop produces: the
+                -- truncated assistant turn followed by developer feedback.
+                -- Models from Sonnet 4.6 on reject any request that ends on an
+                -- assistant turn, so the feedback must reach the model as a
+                -- user message.
+                local contract_args = {
+                    model = "claude-sonnet-5",
+                    messages = {
+                        {
+                            role = "user",
+                            content = {{ type = "text", text = "List three colors, one per line." }}
+                        },
+                        {
+                            role = "assistant",
+                            content = {{ type = "text", text = "Red\nGre" }}
+                        },
+                        {
+                            role = "developer",
+                            content = "Your previous response was truncated. Retry with a complete, shorter response."
+                        }
+                    },
+                    options = {
+                        max_tokens = 100
+                    }
+                }
+
+                local response, err = generate_handler.handler(contract_args)
+
+                test.is_true(response.success, "API request failed: " .. (err or "unknown error"))
+                assert(response.success)
+                test.is_true(#response.result.content > 0, "No content returned")
+            end)
+
             it("should generate text with tool calling using haiku", function()
                 if not RUN_INTEGRATION_TESTS then
                     print("Skipping tool calling test - not enabled")

--- a/src/llm/src/claude/mapper.lua
+++ b/src/llm/src/claude/mapper.lua
@@ -311,15 +311,21 @@ function mapper.map_messages(contract_messages)
                 (type(msg.content) == "table" and msg.content[1] and msg.content[1].text) or ""
 
             if dev_text ~= "" then
-                -- Check if previous message is tool_result (or if no previous messages)
+                -- Developer guidance merges only into a preceding plain user
+                -- message. Anywhere else it opens a new user message: gluing
+                -- it into an assistant message would attribute text the model
+                -- never produced and leave the request ending on an assistant
+                -- turn, which the API treats as a prefill and current models
+                -- reject; after a tool_result it stays a separate message.
                 local should_create_new_message = false
 
                 if #claude_messages == 0 then
                     should_create_new_message = true
                 else
                     local last_msg = claude_messages[#claude_messages]
-                    -- If last message is tool_result, create new user message
-                    if last_msg.role == "user" and last_msg.content and last_msg.content[1] and
+                    if last_msg.role ~= "user" then
+                        should_create_new_message = true
+                    elseif last_msg.content and last_msg.content[1] and
                        last_msg.content[1].type == "tool_result" then
                         should_create_new_message = true
                     end

--- a/src/llm/src/claude/mapper_test.lua
+++ b/src/llm/src/claude/mapper_test.lua
@@ -200,6 +200,52 @@ local function define_tests()
                 test.eq((last_msg.content[1] :: any).type, "image")
             end)
 
+            it("should start a new user message for developer content after an assistant message", function()
+                local contract_messages = {
+                    { role = prompt.ROLE.USER, content = { { type = "text", text = "Import the document" } } },
+                    { role = prompt.ROLE.ASSISTANT, content = { { type = "text", text = "I'll write the sections" } } },
+                    { role = prompt.ROLE.DEVELOPER, content = "Your previous response was truncated. Retry with a shorter response." }
+                }
+
+                local result = mapper.map_messages(contract_messages)
+                test.eq(#result.messages, 3)
+
+                -- The assistant message carries only what the model produced.
+                local assistant_msg = result.messages[2] :: any
+                test.eq(assistant_msg.role, "assistant")
+                test.eq(#assistant_msg.content, 1)
+                test.eq(tostring((assistant_msg.content[1] :: any).text), "I'll write the sections")
+
+                -- Developer guidance lands in the user channel, so the request
+                -- never ends on an assistant turn (rejected as prefill).
+                local last_msg = result.messages[3] :: any
+                test.eq(last_msg.role, "user")
+                test.contains(tostring((last_msg.content[1] :: any).text), "truncated")
+            end)
+
+            it("should never end the mapped conversation with an assistant message when developer feedback follows tool use", function()
+                local contract_messages = {
+                    { role = prompt.ROLE.USER, content = { { type = "text", text = "Ingest the file" } } },
+                    {
+                        role = prompt.ROLE.FUNCTION_CALL,
+                        function_call = { name = "kb_write", arguments = { title = "A" }, id = "call_1" },
+                        content = { { type = "text", text = "Writing the first section" } }
+                    },
+                    {
+                        role = prompt.ROLE.FUNCTION_RESULT,
+                        function_call_id = "call_1",
+                        name = "kb_write",
+                        content = { { type = "text", text = "ok" } }
+                    },
+                    { role = prompt.ROLE.ASSISTANT, content = { { type = "text", text = "Continuing with" } } },
+                    { role = prompt.ROLE.DEVELOPER, content = "Response truncated, retry in smaller steps." }
+                }
+
+                local result = mapper.map_messages(contract_messages)
+                local last_msg = result.messages[#result.messages] :: any
+                test.eq(last_msg.role, "user")
+            end)
+
             it("should convert function calls to assistant tool_use format", function()
                 local contract_messages = {
                     {


### PR DESCRIPTION
## Defect

`claude/mapper.lua` merged `developer`-role content into the previous message regardless of that message's role. Two consequences:

1. **Fabricated model output** — after a truncated agent turn, the truncation-recovery feedback (`<developer-instruction>...`) was appended into the partial *assistant* message, attributing text to the model it never produced.
2. **Trailing-assistant prefill** — the request then ends on an assistant turn. Models from Sonnet 4.6 onward (incl. the Claude 5 family) reject this with HTTP 400: `This model does not support assistant message prefill. The conversation must end with a user message.`

## Observed in production

A `kb_importer` agent dataflow on `claude-sonnet-5` died mid-import, twice, at the first truncated turn (the agent node's truncation recovery stores the partial action and a developer feedback observation — `dataflow/src/node/agent/node.lua` truncation branch — which the mapper then merged into the assistant message). Minimal reproduction against the API returns the same 400 (`req_011CegoQokuK2cP4bx7pw8FP`). On pre-4.6 models the pattern was accidentally functional because the API accepted the prefill.

## Fix

Developer content merges only into a preceding **plain user** message. After an assistant message — or a tool_result — it opens a new user message, so recovery guidance reaches the model on the user turn and the request never ends on an assistant message.

## Tests

- 2 new mapper unit tests (fail on master: `expected "user", got "assistant"`), pinning: developer-after-assistant opens a user message, the assistant message stays byte-identical to what the model produced, and the mapped conversation never ends on an assistant turn.
- 1 new integration test running the truncation-recovery conversation shape against `claude-sonnet-5` through `generate_handler` (400 on master, passes with the fix).
- Full llm suite: 1206 green, lint clean. Existing developer-merge tests (into user / image-only user messages) unchanged and passing.

https://claude.ai/code/session_01GGANLtqTDCWHbSYmycvjpV