### PR TITLE
fix(llm): treat an empty length-cut response as truncation

### DIFF
--- a/src/llm/src/output.lua
+++ b/src/llm/src/output.lua
@@ -431,12 +431,20 @@ end
 -- Message injected into conversation when LLM output is truncated mid-tool-call
 output.TRUNCATION_MSG = "Your previous response was truncated because it exceeded the maximum token limit. The tool calls you attempted were incomplete and have been discarded. Please retry with a shorter response. Break your work into smaller steps if needed."
 
--- Detect truncated LLM responses that contain incomplete tool calls
+-- Detect LLM responses cut off by the token limit that produced nothing
+-- usable: partial tool calls, or no tool calls and no content at all (the
+-- whole budget can burn inside thinking before any deliverable output).
+-- A length-cut response that still carries text is a partial answer and is
+-- returned to the caller as such.
 function output.detect_truncation(result)
     if not result then return false end
     if result.finish_reason ~= output.FINISH_REASON.LENGTH then return false end
-    if not result.tool_calls or #result.tool_calls == 0 then return false end
-    return true
+    if result.tool_calls and #result.tool_calls > 0 then return true end
+    local content = result.content
+    if content == nil or content == "" then
+        content = result.result
+    end
+    return content == nil or content == ""
 end
 
 return output

--- a/src/llm/src/output_test.lua
+++ b/src/llm/src/output_test.lua
@@ -298,12 +298,22 @@ local function define_tests()
                 test.is_true(output.detect_truncation(result))
             end)
 
-            it("should not detect truncation when finish_reason is LENGTH without tool_calls", function()
+            it("should not detect truncation when a LENGTH-cut response still carries text", function()
                 local result = {
                     finish_reason = output.FINISH_REASON.LENGTH,
-                    tool_calls = {}
+                    tool_calls = {},
+                    content = "a partial but usable answer"
                 }
                 test.is_false(output.detect_truncation(result))
+            end)
+
+            it("should detect truncation when LENGTH is hit with no tool calls and no content", function()
+                local result = {
+                    finish_reason = output.FINISH_REASON.LENGTH,
+                    tool_calls = {},
+                    content = ""
+                }
+                test.is_true(output.detect_truncation(result))
             end)
 
             it("should not detect truncation when finish_reason is STOP with tool_calls", function()
@@ -330,10 +340,19 @@ local function define_tests()
                 test.is_false(output.detect_truncation(nil))
             end)
 
-            it("should not detect truncation when tool_calls is nil", function()
+            it("should detect truncation when tool_calls is nil and nothing was produced", function()
                 local result = {
                     finish_reason = output.FINISH_REASON.LENGTH,
                     tool_calls = nil
+                }
+                test.is_true(output.detect_truncation(result))
+            end)
+
+            it("should not detect truncation when tool_calls is nil but result text exists", function()
+                local result = {
+                    finish_reason = output.FINISH_REASON.LENGTH,
+                    tool_calls = nil,
+                    result = "text under the alternate field name"
                 }
                 test.is_false(output.detect_truncation(result))
             end)


### PR DESCRIPTION
## Defect

`output.detect_truncation` flags a `finish_reason: length` response as truncated only when it carries partial tool calls. A response that hits the cap having produced **nothing** — no text, no tool calls — passes as a normal completion.

Observed live (WMU instance, `kb_importer` on `claude-sonnet-5`, `class:balanced`): iteration 2 consumed exactly 8000 completion tokens entirely inside an adaptive-thinking block, returned `{"result":"","tool_calls":[]}` with `finish_reason: "length"`, and the agent workload completed "successfully" having written zero KB entries — deterministically, twice, on the same document.

## Fix

A length-cut response is truncated when it has partial tool calls, **or** no tool calls and no content (checked under both `content` and `result` field names). A length-cut response that still carries text stays a partial answer returned to the caller — chat semantics unchanged.

This routes the empty case into the existing truncation recovery (store turn → inject retry guidance → continue), which is functional as of #114.

## Tests

Two tests that pinned the defective behavior (`LENGTH` without tool calls → never truncation) are split into correct pairs: with text → false, with nothing → true, under both field names. llm suite 1208 green, agent suite 313 green, lint clean.

https://claude.ai/code/session_011evDbMcxWJxqmRatnQ8g4W