### PR TITLE
fix(llm, bootloader, embeddings): declare wippy/security and surface embedding errors

### DIFF
--- a/src/bootloader/src/_index.yaml
+++ b/src/bootloader/src/_index.yaml
@@ -21,7 +21,7 @@ entries:
     meta:
       description: "Security policy groups referenced by background services"
     component: "wippy/security"
-    version: ">=v0.4.0"
+    version: ">=v0.3.0"
 
   # Requirements
   - name: application_host

--- a/src/bootloader/src/_index.yaml
+++ b/src/bootloader/src/_index.yaml
@@ -16,6 +16,13 @@ entries:
     component: "wippy/test"
     version: ">=v0.3.0"
 
+  - name: dep.wippy.security
+    kind: "ns.dependency"
+    meta:
+      description: "Security policy groups referenced by background services"
+    component: "wippy/security"
+    version: ">=v0.4.0"
+
   # Requirements
   - name: application_host
     kind: ns.requirement

--- a/src/embeddings/_index.yaml
+++ b/src/embeddings/_index.yaml
@@ -55,6 +55,25 @@ entries:
       - time
       - registry
 
+  # wippy.embeddings:embeddings_test
+  - name: embeddings_test
+    kind: function.lua
+    meta:
+      name: Embeddings Library Test
+      type: test
+      comment: Tests the embeddings library error reporting
+      group: LLM / Embeddings (SQL)
+      tags:
+        - embeddings
+        - tests
+    source: file://embeddings_test.lua
+    modules:
+      - uuid
+    imports:
+      embeddings: wippy.embeddings:embeddings
+      test: wippy.test:test
+    method: run
+
   # wippy.embeddings:embedding_repo_test
   - name: embedding_repo_test
     kind: function.lua

--- a/src/embeddings/embeddings.lua
+++ b/src/embeddings/embeddings.lua
@@ -59,13 +59,13 @@ local function generate_embedding(text)
     end
 
     -- Use text-embedding model for embeddings
-    local response = llm.embed(text, {
+    local response, err = llm.embed(text, {
         model = EMBEDDING_MODEL,
         dimensions = EMBEDDING_DIMENSIONS
     })
 
-    if not response or response.error then
-        return nil, "Failed to generate embedding: " .. (response and response.error_message or "Unknown error")
+    if not response then
+        return nil, "Failed to generate embedding: " .. (err or "Unknown error")
     end
 
     return response.result
@@ -93,13 +93,13 @@ local function generate_batch_embeddings(texts)
     end
 
     -- Use text-embedding model for embeddings in batch
-    local response = llm.embed(texts, {
+    local response, err = llm.embed(texts, {
         model = EMBEDDING_MODEL,
         dimensions = EMBEDDING_DIMENSIONS
     })
 
-    if not response or response.error then
-        return nil, "Failed to generate batch embeddings: " .. (response and response.error_message or "Unknown error")
+    if not response then
+        return nil, "Failed to generate batch embeddings: " .. (err or "Unknown error")
     end
 
     return response.result

--- a/src/embeddings/embeddings_test.lua
+++ b/src/embeddings/embeddings_test.lua
@@ -1,0 +1,32 @@
+local test = require("test")
+local uuid = require("uuid")
+local embeddings = require("embeddings")
+
+local function define_tests()
+    test.describe("Embeddings library", function()
+        test.it("reports the provider error when embedding generation fails", function()
+            -- The test application declares no llm.model entry, so llm.embed
+            -- fails and the failure must reach the caller verbatim.
+            local result, err = embeddings.add(
+                "Document used to exercise the embedding failure path.",
+                "embeddings_test_document",
+                uuid.v4(),
+                "embeddings_test_context",
+                {}
+            )
+
+            test.is_nil(result)
+            test.not_nil(err)
+            test.is_true(
+                tostring(err):find("Model or class not found", 1, true) ~= nil,
+                "expected the llm.embed error in the message, got: " .. tostring(err)
+            )
+            test.is_true(
+                tostring(err):find("Unknown error", 1, true) == nil,
+                "underlying error was replaced by a placeholder: " .. tostring(err)
+            )
+        end)
+    end)
+end
+
+return test.run_cases(define_tests)

--- a/src/llm/src/_index.yaml
+++ b/src/llm/src/_index.yaml
@@ -94,7 +94,7 @@ entries:
     meta:
       description: "Security policy groups referenced by background services"
     component: "wippy/security"
-    version: ">=v0.4.0"
+    version: ">=v0.3.0"
 
   # wippy.llm:embedder
   - name: embedder

--- a/src/llm/src/_index.yaml
+++ b/src/llm/src/_index.yaml
@@ -89,6 +89,13 @@ entries:
     component: "wippy/test"
     version: ">=v0.4.0"
 
+  - name: dep.wippy.security
+    kind: "ns.dependency"
+    meta:
+      description: "Security policy groups referenced by background services"
+    component: "wippy/security"
+    version: ">=v0.4.0"
+
   # wippy.llm:embedder
   - name: embedder
     kind: contract.definition


### PR DESCRIPTION
Found while running the docs tutorials against a runtime v0.3.40a build (strict security on by default).

**wippy/llm and wippy/bootloader reference a policy group they never depend on.** `wippy.llm.bedrock:credential_refresher.service`, `wippy.llm.google.oauth2:token_refresher.service` and `wippy.bootloader:bootloader.service` declare `lifecycle.security.groups: [wippy.security:process]`, but neither module declared an `ns.dependency` on `wippy/security`. Any application that does not add `wippy/security` itself fails at boot with `resolve security policy group wippy.security:process: policy group not found` followed by `failed to execute commit protocol`. Both modules now declare `dep.wippy.security` (`>=v0.3.0`; 0.3.8 already provides the group, verified by booting a service under it).

**wippy/embeddings hid the real error.** `generate_embedding` and `generate_batch_embeddings` ignored the error value `llm.embed` returns and reported every failure as `Failed to generate embedding: Unknown error` (`EmbedResponse` has no `error` field, so that branch was dead). They now pass the provider message through. New `wippy.embeddings:embeddings_test` covers the failure path: red on the old code (`Unknown error`), green after.

**Verification on v0.3.40a** (module tests run with `--set security.strict_mode=false`, which the `wippy.test` runner needs on this runtime to discover entries):
- llm 1208 passed before and after; bootloader 15/15; actor 21/21; agent 313/313.
- embeddings: 0/11 before (the suite was already broken: with nothing depending on `wippy/security` the bootloader failed and migrations never ran) → 12/12 after.
- Fresh app depending only on `wippy/llm`: `wippy/security` is pulled transitively, both refresher services start. With an explicit root dependency on `wippy/security` as well: resolves once, no conflict. Same for `wippy/bootloader`.
- Existing apps (app-template, kb-central) with the worktree substituted via replacements: install and boot unchanged.
- `wippy lint --level error` clean for llm, bootloader, embeddings; `scripts/check_module_manifests.py` passes.

Applications whose lock predates this change gain `wippy/security` on the next `wippy run` (online) or `wippy update`.

